### PR TITLE
Fix terraform validation errors in outputs.tf

### DIFF
--- a/terraform/implementations/aws/infra/outputs.tf
+++ b/terraform/implementations/aws/infra/outputs.tf
@@ -39,20 +39,3 @@ output "vpc_id" {
   description = "VPC ID"
   value       = module.mosip_infra.vpc_id
 }
-
-# RKE2 Deployment Information
-output "rke2_deployment_info" {
-  description = "RKE2 deployment information including Cloud-Init data and instructions"
-  value       = module.mosip_infra.rke2_deployment_info
-}
-
-# Quick access to deployment method and kubeconfig location
-output "deployment_summary" {
-  description = "Summary of deployment method and file locations"
-  value = {
-    deployment_method     = try(module.mosip_infra.rke2_deployment_info.deployment_method, "Unknown")
-    kubeconfig_location   = try(module.mosip_infra.rke2_deployment_info.kubeconfig_files_location, "Unknown")
-    control_plane_nodes   = try(module.mosip_infra.rke2_deployment_info.control_plane_nodes, {})
-    kubectl_usage_example = try(module.mosip_infra.rke2_deployment_info.kubectl_usage, "Run terraform apply to see instructions")
-  }
-}


### PR DESCRIPTION
- Remove rke2_deployment_info and deployment_summary outputs that don't exist in the module
- These outputs were incorrectly added during merge conflict resolution
- Configuration now validates successfully