### PR TITLE
[MOSIP-44613]fix :Resolve unsupported ACTIVEMQ_NFS_ALLOWED_HOSTS argument in Terr…

### DIFF
--- a/terraform/infra/aws/main.tf
+++ b/terraform/infra/aws/main.tf
@@ -58,5 +58,5 @@ module "aws_infrastructure" {
   nginx_node_ebs_volume_size_3 = var.nginx_node_ebs_volume_size_3
   activemq_storage_device      = var.activemq_storage_device
   activemq_mount_point         = var.activemq_mount_point
-  ACTIVEMQ_NFS_ALLOWED_HOSTS   = var.activemq_nfs_allowed_hosts
+  activemq_nfs_allowed_hosts   = var.activemq_nfs_allowed_hosts
 }

--- a/terraform/modules/aws/aws-main.tf
+++ b/terraform/modules/aws/aws-main.tf
@@ -549,6 +549,7 @@ module "activemq-setup" {
   NGINX_NODE_EBS_VOLUME_SIZE_3 = var.nginx_node_ebs_volume_size_3
   ACTIVEMQ_STORAGE_DEVICE      = var.activemq_storage_device
   ACTIVEMQ_MOUNT_POINT         = var.activemq_mount_point
+  ACTIVEMQ_NFS_ALLOWED_HOSTS   = var.activemq_nfs_allowed_hosts
 
   # Control plane for applying the StorageClass to Kubernetes
   CONTROL_PLANE_HOST = [for instance in module.aws-resource-creation.K8S_CLUSTER_PRIVATE_IPS : instance][0]

--- a/terraform/modules/aws/variables.tf
+++ b/terraform/modules/aws/variables.tf
@@ -233,3 +233,9 @@ variable "activemq_mount_point" {
     error_message = "activemq_mount_point must be a valid absolute directory path (e.g., /srv/activemq)."
   }
 }
+
+variable "activemq_nfs_allowed_hosts" {
+  description = "Hosts allowed to mount the NFS export (written to /etc/exports). Use '*' for any host or a CIDR/IP range e.g. '10.0.0.0/8'."
+  type        = string
+  default     = "*"
+}


### PR DESCRIPTION
…aform module chain

- Rename ACTIVEMQ_NFS_ALLOWED_HOSTS to activemq_nfs_allowed_hosts in infra/aws/main.tf to match module variable naming convention
- Add missing activemq_nfs_allowed_hosts variable to modules/aws/variables.tf
- Pass ACTIVEMQ_NFS_ALLOWED_HOSTS through to activemq-setup submodule in aws-main.tf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored and enhanced infrastructure configuration by standardizing variable naming and introducing a new parameter for ActiveMQ NFS access permissions. System administrators can now configure which hosts are allowed to mount the NFS export using IP addresses, CIDR ranges, or wildcards, with default settings permitting all hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->