### PR TITLE
[MOSIP-44608] updated terraform script to support ebs volume for acti…

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,7 @@ This step creates MOSIP Kubernetes cluster, PostgreSQL (if enabled), networking,
  enable_activemq_setup = true # Enable ActiveMQ persistent storage for main infra
  activemq_storage_device = "/dev/nvme3n1"
  activemq_mount_point = "/srv/activemq"
+ activemq_nfs_allowed_hosts = "*" # Hosts allowed to mount NFS export (use CIDR/IP range for production, e.g., "10.0.0.0/8")
 
  # MOSIP Infrastructure Repository Configuration
  mosip_infra_repo_url = "https://github.com/mosip/mosip-infra.git"

--- a/README.md
+++ b/README.md
@@ -675,6 +675,8 @@ This step creates MOSIP Kubernetes cluster, PostgreSQL (if enabled), networking,
  nginx_node_ebs_volume_size = 300
  # NGINX node's second EBS volume size (optional - set to 0 to disable)
  nginx_node_ebs_volume_size_2 = 200 # Enable second EBS volume for PostgreSQL testing
+ # NGINX node's third EBS volume size (optional - set to 0 to disable)
+ nginx_node_ebs_volume_size_3 = 100 # Enable third EBS volume for ActiveMQ storage
  # Kubernetes nodes Root volume size
  k8s_instance_root_volume_size = 64
 
@@ -708,6 +710,11 @@ This step creates MOSIP Kubernetes cluster, PostgreSQL (if enabled), networking,
  mount_point = "/srv/postgres"
  postgresql_port = "5433"
 
+ # ActiveMQ Configuration (optional, used when third EBS volume is enabled)
+ enable_activemq_setup = true # Enable ActiveMQ persistent storage for main infra
+ activemq_storage_device = "/dev/nvme3n1"
+ activemq_mount_point = "/srv/activemq"
+
  # MOSIP Infrastructure Repository Configuration
  mosip_infra_repo_url = "https://github.com/mosip/mosip-infra.git"
  mosip_infra_branch = "develop"
@@ -733,6 +740,8 @@ This step creates MOSIP Kubernetes cluster, PostgreSQL (if enabled), networking,
 | `nginx_node_ebs_volume_size_2` | EBS volume size for PostgreSQL data (GB)   | `200`                                     |
 | `postgresql_version`           | PostgreSQL version to install              | `"15"`                                    |
 | `postgresql_port`              | PostgreSQL service port                    | `"5433"`                                  |
+| `enable_activemq_setup`        | ActiveMQ persistent storage setup          | `true` (provisioned) / `false` (skipped) |
+| `nginx_node_ebs_volume_size_3` | EBS volume size for ActiveMQ data (GB)     | `100`                                     |
 | `vpc_name`                     | Existing VPC name tag to use               | `"mosip-boxes"`                           |
 
 > **Important Notes:**
@@ -748,6 +757,7 @@ This step creates MOSIP Kubernetes cluster, PostgreSQL (if enabled), networking,
 
 > - Set `enable_postgresql_setup = false` for development deployments with containerized PostgreSQL
 > - The `nginx_node_ebs_volume_size_2` is required when `enable_postgresql_setup = true`
+> - **ActiveMQ Setup**: ActiveMQ installation is optional. To enable it, set `enable_activemq_setup = true` and ensure `nginx_node_ebs_volume_size_3 > 0` in `aws.tfvars`. It automatically provisions durable NFS-backed persistent storage via a dedicated EBS volume on the NGINX node.
 > - **SSH Key Configuration**: The `ssh_key_name` value must match the repository secret name containing your SSH private key (e.g., if `ssh_key_name = "mosip-aws"`, create repository secret named `mosip-aws` with your SSH private key content)
 
 #### Rancher Import Configuration (Optional)

--- a/terraform/modules/aws/activemq-setup/README.md
+++ b/terraform/modules/aws/activemq-setup/README.md
@@ -38,9 +38,9 @@ This Terraform module provisions the necessary persistent storage infrastructure
 | `NGINX_NODE_EBS_VOLUME_SIZE_3` | Size of the 3rd EBS volume attached to the target NGINX node         | `number` | n/a               | Yes      |
 | `ACTIVEMQ_STORAGE_DEVICE`      | Block device path of the 3rd EBS volume                              | `string` | `/dev/nvme3n1`    | No       |
 | `ACTIVEMQ_MOUNT_POINT`         | Mount point for ActiveMQ persistent storage & NFS share path         | `string` | `/srv/activemq`   | No       |
+| `ACTIVEMQ_NFS_ALLOWED_HOSTS`   | Hosts allowed to mount the NFS export (e.g., `*` or `10.0.0.0/8`)   | `string` | `*`               | No       |
 | `CONTROL_PLANE_HOST`           | IP address of the Kubernetes control plane node                      | `string` | n/a               | Yes      |
 | `CONTROL_PLANE_USER`           | SSH username for control plane access                                | `string` | `ubuntu`          | No       |
-
 ## Security Considerations
 
 The `SSH_PRIVATE_KEY` is passed seamlessly through the environment (`TF_ACTIVEMQ_SSH_KEY`) and is never included in commandline arguments. The bash wrapper creates a temporary key file with `600` permissions and automatically removes it via bash `trap` signals (like `EXIT` or `ERR`) after the pipeline completes, guaranteeing that sensitive keys are not leaked in CI/CD pipeline logs, tfstate command histories, or process lists.

--- a/terraform/modules/aws/activemq-setup/README.md
+++ b/terraform/modules/aws/activemq-setup/README.md
@@ -1,0 +1,46 @@
+# AWS ActiveMQ Setup Module
+
+This Terraform module provisions the necessary persistent storage infrastructure for ActiveMQ inside a Kubernetes cluster. It leverages an EBS volume attached to an existing NGINX node, re-exports it via an NFS server, and registers a Kubernetes `StorageClass` to allow pods to dynamically consume it.
+
+## Architecture & Data Flow
+
+1. **EBS Volume Formatting & NFS Setup**
+   - Controlled by the `null_resource.activemq-ebs-nfs-setup` resource.
+   - Terraform triggers a `local-exec` provisioner running a bash wrapper (`activemq-setup.sh`).
+   - The bash wrapper prepares an Ansible environment and invokes `activemq-setup.yml`.
+   - **Ansible Execution**:
+     - Connects via SSH securely to the NGINX node.
+     - Waits for the ActiveMQ EBS block device (e.g., `/dev/nvme3n1`) to appear.
+     - Formats the EBS volume as an `xfs` filesystem (if not already formatted).
+     - Resolves the stable block device UUID and mounts it to `/srv/activemq`, avoiding device renaming issues.
+     - Sets up and enables an NFS kernel server, exporting the mount point `/srv/activemq`.
+     - Generates the Kubernetes `StorageClass` YAML artifact (`/tmp/activemq-storageclass.yaml`) locally on the Terraform runner.
+
+2. **Kubernetes StorageClass Provisioning**
+   - Controlled by the `null_resource.activemq-k8s-storageclass` resource, which runs after the NFS setup.
+   - Terraform connects to the Kubernetes control plane via a `remote-exec` SSH provisioner.
+   - It copies the generated `StorageClass` YAML from the runner to the control plane.
+   - Uses `kubectl` to apply the YAML (`nfs-csi-activemq`), so that ActiveMQ Helm charts can reference this `StorageClass`.
+
+## File Structure
+
+- **`main.tf`**: The primary Terraform module defining the `null_resource` blocks for the local Ansible execution and remote Kubernetes configuration.
+- **`activemq-setup.sh`**: A wrapper bash script that validates inputs, sets up a temporary Ansible workspace (inventory and configs), robustly manages SSH keys, and runs the playbook.
+- **`activemq-setup.yml`**: The Ansible playbook that performs the system-level formatting, mounting, and NFS configuration on the target node.
+
+## Inputs
+
+| Name                           | Description                                                          | Type     | Default           | Required |
+|--------------------------------|----------------------------------------------------------------------|----------|-------------------|:--------:|
+| `NGINX_PUBLIC_IP`              | Public IP of the NGINX node                                          | `string` | n/a               | Yes      |
+| `NGINX_PRIVATE_IP`             | Private IP of the NGINX node                                         | `string` | n/a               | Yes      |
+| `SSH_PRIVATE_KEY`              | Sensitive SSH private key content to access nodes                    | `string` | n/a               | Yes      |
+| `NGINX_NODE_EBS_VOLUME_SIZE_3` | Size of the 3rd EBS volume attached to the target NGINX node         | `number` | n/a               | Yes      |
+| `ACTIVEMQ_STORAGE_DEVICE`      | Block device path of the 3rd EBS volume                              | `string` | `/dev/nvme3n1`    | No       |
+| `ACTIVEMQ_MOUNT_POINT`         | Mount point for ActiveMQ persistent storage & NFS share path         | `string` | `/srv/activemq`   | No       |
+| `CONTROL_PLANE_HOST`           | IP address of the Kubernetes control plane node                      | `string` | n/a               | Yes      |
+| `CONTROL_PLANE_USER`           | SSH username for control plane access                                | `string` | `ubuntu`          | No       |
+
+## Security Considerations
+
+The `SSH_PRIVATE_KEY` is passed seamlessly through the environment (`TF_ACTIVEMQ_SSH_KEY`) and is never included in commandline arguments. The bash wrapper creates a temporary key file with `600` permissions and automatically removes it via bash `trap` signals (like `EXIT` or `ERR`) after the pipeline completes, guaranteeing that sensitive keys are not leaked in CI/CD pipeline logs, tfstate command histories, or process lists.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for optional ActiveMQ storage configuration on the NGINX node.
  * Introduced new configuration variables: `enable_activemq_setup`, `activemq_storage_device`, and `activemq_mount_point`.
  * Added comprehensive setup guide for ActiveMQ persistent storage provisioning in Kubernetes clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->