### PR TITLE
[MOSIP-41451] Added missing UUID Mapping in Terraform Script for /etc/fstab

### DIFF
--- a/Helmsman/utils/ansible/postgresql-setup.yml
+++ b/Helmsman/utils/ansible/postgresql-setup.yml
@@ -150,11 +150,19 @@
         dev: "{{ postgres_device }}"
         force: no
       when: mount_check.rc != 0
+
+    - name: Resolve filesystem UUID of the device
+      command: blkid -o value -s UUID "{{ postgres_device }}"
+      register: device_uuid
+      changed_when: false
+      retries: 3
+      delay: 5
+      until: device_uuid.stdout != ""
       
     - name: Create mount point and mount device
       mount:
         path: "{{ postgres_mount }}"
-        src: "{{ postgres_device }}"
+        src: "UUID={{ device_uuid.stdout | trim }}"
         fstype: xfs
         opts: defaults,noatime
         state: mounted

--- a/terraform/modules/aws/aws-resource-creation/variables.tf
+++ b/terraform/modules/aws/aws-resource-creation/variables.tf
@@ -130,7 +130,8 @@ echo "[ Mount EBS volume to /srv/nfs directory ] : "
 file -s /dev/nvme1n1
 mkfs -t xfs /dev/nvme1n1
 mkdir -p /srv/nfs
-echo "/dev/nvme1n1    /srv/nfs xfs  defaults,nofail  0  2" >> /etc/fstab
+UUID=$(blkid -o value -s UUID /dev/nvme1n1)
+echo "UUID=$UUID    /srv/nfs xfs  defaults,nofail  0  2" >> /etc/fstab
 mount -a
 systemctl daemon-reload
 

--- a/terraform/modules/aws/aws-resource-creation/variables.tf
+++ b/terraform/modules/aws/aws-resource-creation/variables.tf
@@ -127,17 +127,24 @@ set -o pipefail  # trace ERR through pipes
 
 ## Mount EBS volume
 echo "[ Mount EBS volume to /srv/nfs directory ] : "
-file -s /dev/nvme1n1
-mkfs -t xfs /dev/nvme1n1
+
+if ! file -s /dev/nvme1n1 | grep -q filesystem; then
+  mkfs -t xfs /dev/nvme1n1
+fi
+
 mkdir -p /srv/nfs
 UUID=$(blkid -o value -s UUID /dev/nvme1n1)
-echo "UUID=$UUID    /srv/nfs xfs  defaults,nofail  0  2" >> /etc/fstab
+
+if ! grep -q "$UUID" /etc/fstab; then
+  echo "UUID=$UUID    /srv/nfs xfs  defaults,nofail  0  2" >> /etc/fstab
+fi
 mount -a
 systemctl daemon-reload
 
 export TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
 echo "export TOKEN=$TOKEN" | sudo tee -a $ENV_FILE_PATH
 echo "export INTERNAL_IP=\"$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4)\"" | sudo tee -a $ENV_FILE_PATH
+
 EOF
     tags = {
       Name    = local.TAG_NAME.NGINX_TAG_NAME

--- a/terraform/modules/aws/aws-resource-creation/variables.tf
+++ b/terraform/modules/aws/aws-resource-creation/variables.tf
@@ -127,24 +127,17 @@ set -o pipefail  # trace ERR through pipes
 
 ## Mount EBS volume
 echo "[ Mount EBS volume to /srv/nfs directory ] : "
-
-if ! file -s /dev/nvme1n1 | grep -q filesystem; then
-  mkfs -t xfs /dev/nvme1n1
-fi
-
+file -s /dev/nvme1n1
+mkfs -t xfs /dev/nvme1n1
 mkdir -p /srv/nfs
 UUID=$(blkid -o value -s UUID /dev/nvme1n1)
-
-if ! grep -q "$UUID" /etc/fstab; then
-  echo "UUID=$UUID    /srv/nfs xfs  defaults,nofail  0  2" >> /etc/fstab
-fi
+echo "UUID=$UUID    /srv/nfs xfs  defaults,nofail  0  2" >> /etc/fstab
 mount -a
 systemctl daemon-reload
 
 export TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
 echo "export TOKEN=$TOKEN" | sudo tee -a $ENV_FILE_PATH
 echo "export INTERNAL_IP=\"$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4)\"" | sudo tee -a $ENV_FILE_PATH
-
 EOF
     tags = {
       Name    = local.TAG_NAME.NGINX_TAG_NAME

--- a/terraform/modules/aws/aws-resource-creation/variables.tf
+++ b/terraform/modules/aws/aws-resource-creation/variables.tf
@@ -131,7 +131,13 @@ file -s /dev/nvme1n1
 mkfs -t xfs /dev/nvme1n1
 mkdir -p /srv/nfs
 UUID=$(blkid -o value -s UUID /dev/nvme1n1)
-echo "UUID=$UUID    /srv/nfs xfs  defaults,nofail  0  2" >> /etc/fstab
+if [ -z "$UUID" ]; then
+  echo "Failed to resolve UUID for /dev/nvme1n1" >&2
+  exit 1
+fi
+if ! grep -qE "^[[:space:]]*UUID=$UUID[[:space:]]+/srv/nfs[[:space:]]+xfs[[:space:]]+" /etc/fstab; then
+  echo "UUID=$UUID    /srv/nfs xfs  defaults,nofail  0  2" >> /etc/fstab
+fi
 mount -a
 systemctl daemon-reload
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure Updates**
  * Storage mounts for PostgreSQL and EC2 instances now use UUID-based identifiers instead of fixed device paths. Includes resilient UUID resolution with retries and safer fstab handling to avoid duplicate or incorrect entries, improving mount reliability across reboots and hardware changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->