### PR TITLE
[Fixes: mosip/mosip-infra#1874] Added wg-onboard.sh for WireGuard onboarding automation

### DIFF
--- a/.github/scripts/wg-onboard.sh
+++ b/.github/scripts/wg-onboard.sh
@@ -136,11 +136,18 @@ log "Target repo: $REPO"
 log "Target environment: $ENV_NAME (label: $LABEL)"
 log "WireGuard dir: $WG_DIR | AllowedIPs: $ALLOWED_IPS"
 
+SSH_KNOWN_HOSTS_IS_TEMP="false"
+wg_onboard_exit_cleanup() {
+  [[ -n "${TMP:-}" && -f "$TMP" ]] && rm -f "$TMP"
+  [[ "$SSH_KNOWN_HOSTS_IS_TEMP" == "true" ]] && rm -f "$SSH_KNOWN_HOSTS"
+}
+trap wg_onboard_exit_cleanup EXIT
+
 if [[ -n "${SSH_KNOWN_HOSTS:-}" ]]; then
   [[ -f "$SSH_KNOWN_HOSTS" ]] || die "SSH_KNOWN_HOSTS file not found: $SSH_KNOWN_HOSTS"
 else
   SSH_KNOWN_HOSTS="$(mktemp /tmp/wg_onboard_known_hosts.XXXXXX)"
-  trap 'rm -f "$SSH_KNOWN_HOSTS"' EXIT
+  SSH_KNOWN_HOSTS_IS_TEMP="true"
 fi
 
 ssh_cmd() {
@@ -675,11 +682,10 @@ if ! flock -w 30 8; then
   die "Timed out waiting to update repo tracker lock ${ALLOCATION_FILE}.lock"
 fi
 TMP="$(mktemp)"
-trap 'rm -f "$TMP"' EXIT
 awk -F '\t' -v env="$ENV_NAME" 'NR == 1 || $1 != env' "$ALLOCATION_FILE" > "$TMP"
 printf '%s\t%s\t%s\t%s\t%s\n' "$ENV_NAME" "$TF_PEER" "$WG0_PEER" "$WG1_PEER" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$TMP"
 mv "$TMP" "$ALLOCATION_FILE"
-trap - EXIT
+TMP=""
 
 log "Done. Environment '$ENV_NAME' onboarded with peers TF=$TF_PEER WG0=$WG0_PEER WG1=$WG1_PEER."
 log "Server tracker: $ASSIGNED_FILE | repo tracker: $ALLOCATION_FILE (commit it)."

--- a/.github/scripts/wg-onboard.sh
+++ b/.github/scripts/wg-onboard.sh
@@ -128,7 +128,8 @@ fi
 
 CONFIG_DIR="$WG_DIR/config"
 ASSIGNED_FILE="$WG_DIR/assigned.txt"
-ASSIGN_LOCK_FILE="${ASSIGNED_FILE}.lock"
+# Flock lock in /tmp — WG_DIR often cannot create new files (docker/root ownership).
+ASSIGN_LOCK_FILE="/tmp/wg-onboard-$(printf '%s' "$ASSIGNED_FILE" | cksum | awk '{print $1}').lock"
 LABEL="$ENV_NAME"
 [[ -n "$TICKET" ]] && LABEL="${ENV_NAME}(${TICKET})"
 
@@ -176,7 +177,7 @@ highest_config_peer() {
 
 if [[ -z "$MAX_PEERS" ]]; then
   max="$(highest_config_peer)"
-  MAX_PEERS=$(( max > 100 ? max : 100 ))
+  MAX_PEERS=$(( max > 300 ? max : 300 ))
 else
   [[ "$MAX_PEERS" =~ ^[0-9]+$ && "$MAX_PEERS" -gt 0 ]] || die "--max-peers must be a positive integer"
   detected_max="$(highest_config_peer)"
@@ -202,9 +203,13 @@ peer_config_exists() {
 # Runs atomically on the VM before secrets are published (eliminates the race
 # where two workflows read the same free peers and both append assigned.txt).
 atomic_allocate_peers() {
+  # SSH omits empty argv entries; placeholders keep arg positions stable for bash -s.
+  local force_tf="${TF_PEER:-__none__}"
+  local force_wg0="${WG0_PEER:-__none__}"
+  local force_wg1="${WG1_PEER:-__none__}"
   ssh_cmd bash -s \
     "$ASSIGNED_FILE" "$ASSIGN_LOCK_FILE" "$CONFIG_DIR" "$ENV_NAME" "$LABEL" \
-    "$MAX_PEERS" "$TF_PEER" "$WG0_PEER" "$WG1_PEER" "$DRY_RUN" "$CAN_CREATE_PEERS" \
+    "$MAX_PEERS" "$force_tf" "$force_wg0" "$force_wg1" "$DRY_RUN" "$CAN_CREATE_PEERS" \
     <<'REMOTE_ATOMIC_ALLOCATE'
 set -euo pipefail
 
@@ -214,11 +219,14 @@ CONFIG_DIR="$3"
 ENV_NAME="$4"
 LABEL="$5"
 MAX_PEERS="$6"
-FORCE_TF="$7"
-FORCE_WG0="$8"
-FORCE_WG1="$9"
-DRY_RUN="${10}"
-CAN_CREATE="${11}"
+FORCE_TF="${7:-}"
+FORCE_WG0="${8:-}"
+FORCE_WG1="${9:-}"
+[[ "$FORCE_TF" == "__none__" ]] && FORCE_TF=""
+[[ "$FORCE_WG0" == "__none__" ]] && FORCE_WG0=""
+[[ "$FORCE_WG1" == "__none__" ]] && FORCE_WG1=""
+DRY_RUN="${10:-false}"
+CAN_CREATE="${11:-false}"
 
 PARSED_PEER=""
 PARSED_LABEL=""
@@ -467,9 +475,14 @@ run_allocation() {
     "$format" "$reused" "$tf" "$wg0" "$wg1"
 }
 
-exec 9>"$LOCK_FILE"
+exec 9>"$LOCK_FILE" || { echo "ERROR: cannot create allocation lock ($LOCK_FILE)" >&2; exit 1; }
 if ! flock -w 120 9; then
   echo "ERROR: timed out waiting for allocation lock ($LOCK_FILE)" >&2
+  exit 1
+fi
+wg_dir="$(dirname "$ASSIGNED_FILE")"
+if [[ ! -w "$ASSIGNED_FILE" && ! -w "$wg_dir" ]]; then
+  echo "ERROR: cannot write $ASSIGNED_FILE (check ownership/permissions on $wg_dir)" >&2
   exit 1
 fi
 run_allocation

--- a/.github/scripts/wg-onboard.sh
+++ b/.github/scripts/wg-onboard.sh
@@ -256,21 +256,23 @@ peer_label_is_taken() {
 
 record_assignment() {
   local peer="$1" assignment="$2" format="$3" file="$4"
+  local safe_assignment="${assignment//\\/\\\\}"
+  safe_assignment="${safe_assignment//&/\\&}"
   if [[ "$format" == "colon" ]]; then
-    local line="${peer}: ${assignment}"
+    local line="${peer}: ${safe_assignment}"
     if grep -qE "^${peer}:" "$file"; then
       sed -i "s|^${peer}:.*|${line}|" "$file"
     elif grep -qE "^${peer}([[:space:]]|$)" "$file"; then
       sed -i "s|^${peer}.*|${line}|" "$file"
     else
-      printf '%s\n' "$line" >> "$file"
+      printf '%s\n' "${peer}: ${assignment}" >> "$file"
     fi
   else
-    local line="${peer} ${assignment}"
+    local line="${peer} ${safe_assignment}"
     if grep -qE "^${peer}([[:space:]]|$)" "$file"; then
       sed -i "s|^${peer}.*|${line}|" "$file"
     else
-      printf '%s\n' "$line" >> "$file"
+      printf '%s\n' "${peer} ${assignment}" >> "$file"
     fi
   fi
 }
@@ -347,7 +349,7 @@ AllowedIPs = ${CLIENT_IP}/32
 
 EOF
 
-  docker exec "$C" wg set wg0 peer "$PUB" preshared-key "$PSK" allowed-ips "${CLIENT_IP}/32" \
+  echo "$PSK" | docker exec -i "$C" sh -c 'cat > /tmp/psk.tmp && wg set wg0 peer "'"$PUB"'" preshared-key /tmp/psk.tmp allowed-ips "'"${CLIENT_IP}/32"'" && rm -f /tmp/psk.tmp' \
     || docker restart "$C" >/dev/null
 }
 

--- a/.github/scripts/wg-onboard.sh
+++ b/.github/scripts/wg-onboard.sh
@@ -128,7 +128,6 @@ fi
 
 CONFIG_DIR="$WG_DIR/config"
 ASSIGNED_FILE="$WG_DIR/assigned.txt"
-# Flock lock in /tmp — WG_DIR often cannot create new files (docker/root ownership).
 ASSIGN_LOCK_FILE="/tmp/wg-onboard-$(printf '%s' "$ASSIGNED_FILE" | cksum | awk '{print $1}').lock"
 LABEL="$ENV_NAME"
 [[ -n "$TICKET" ]] && LABEL="${ENV_NAME}(${TICKET})"
@@ -150,6 +149,8 @@ ssh_cmd() {
     -o StrictHostKeyChecking=accept-new \
     -o UserKnownHostsFile="$SSH_KNOWN_HOSTS" \
     -o ConnectTimeout=15 \
+    -o ServerAliveInterval=30 \
+    -o ServerAliveCountMax=3 \
     "${SSH_USER}@${JUMPSERVER_HOST}" "$@"
 }
 
@@ -177,7 +178,7 @@ highest_config_peer() {
 
 if [[ -z "$MAX_PEERS" ]]; then
   max="$(highest_config_peer)"
-  MAX_PEERS=$(( max > 300 ? max : 300 ))
+  MAX_PEERS=$(( max > 100 ? max : 100 ))
 else
   [[ "$MAX_PEERS" =~ ^[0-9]+$ && "$MAX_PEERS" -gt 0 ]] || die "--max-peers must be a positive integer"
   detected_max="$(highest_config_peer)"
@@ -199,9 +200,8 @@ peer_config_exists() {
   ssh_cmd "test -f '$CONFIG_DIR/$peer/$peer.conf'" 2>/dev/null
 }
 
-# ---- Flock-guarded read → select → record on the jumpserver ---------------
-# Runs atomically on the VM before secrets are published (eliminates the race
-# where two workflows read the same free peers and both append assigned.txt).
+# ---- Flock-guarded peer allocation/record on the jumpserver ----------------
+# Selection and assigned.txt recording happen under one lock to prevent races.
 atomic_allocate_peers() {
   # SSH omits empty argv entries; placeholders keep arg positions stable for bash -s.
   local force_tf="${TF_PEER:-__none__}"
@@ -266,23 +266,51 @@ record_assignment() {
   local peer="$1" assignment="$2" format="$3" file="$4"
   local safe_assignment="${assignment//\\/\\\\}"
   safe_assignment="${safe_assignment//&/\\&}"
+  local tmp
+  tmp="$(mktemp)"
   if [[ "$format" == "colon" ]]; then
-    local line="${peer}: ${safe_assignment}"
-    if grep -qE "^${peer}:" "$file"; then
-      sed -i "s|^${peer}:.*|${line}|" "$file"
-    elif grep -qE "^${peer}([[:space:]]|$)" "$file"; then
-      sed -i "s|^${peer}.*|${line}|" "$file"
-    else
-      printf '%s\n' "${peer}: ${assignment}" >> "$file"
-    fi
+    awk -v peer="$peer" -v assignment="$assignment" '
+      BEGIN {
+        replaced=0
+        new_line=peer ": " assignment
+      }
+      $1 ~ ("^" peer ":$") || $1 ~ ("^" peer "$") {
+        if (!replaced) {
+          print new_line
+          replaced=1
+        }
+        next
+      }
+      { print }
+      END {
+        if (!replaced) {
+          print new_line
+        }
+      }
+    ' "$file" > "$tmp"
   else
-    local line="${peer} ${safe_assignment}"
-    if grep -qE "^${peer}([[:space:]]|$)" "$file"; then
-      sed -i "s|^${peer}.*|${line}|" "$file"
-    else
-      printf '%s\n' "${peer} ${assignment}" >> "$file"
-    fi
+    awk -v peer="$peer" -v assignment="$assignment" '
+      BEGIN {
+        replaced=0
+        new_line=peer " " assignment
+      }
+      $1 ~ ("^" peer ":?$") {
+        if (!replaced) {
+          print new_line
+          replaced=1
+        }
+        next
+      }
+      { print }
+      END {
+        if (!replaced) {
+          print new_line
+        }
+      }
+    ' "$file" > "$tmp"
   fi
+  cat "$tmp" > "$file"
+  rm -f "$tmp"
 }
 
 ensure_peer_conf() {
@@ -358,13 +386,35 @@ AllowedIPs = ${CLIENT_IP}/32
 EOF
 
   echo "$PSK" | docker exec -i "$C" sh -c 'cat > /tmp/psk.tmp && wg set wg0 peer "'"$PUB"'" preshared-key /tmp/psk.tmp allowed-ips "'"${CLIENT_IP}/32"'" && rm -f /tmp/psk.tmp' \
-    || docker restart "$C" >/dev/null
+    || { echo "ERROR: failed updating WireGuard runtime for $PEER_ID" >&2; return 1; }
+}
+
+mosip_peer_for_secret() {
+  local secret="$1" content="$2"
+  awk -v env="$ENV_NAME" -v secret="$secret" '
+    $1 ~ /^peer[0-9]+:?$/ {
+      peer=$1; sub(/:$/, "", peer)
+      desc=$0; sub(/^[[:space:]]*peer[0-9]+[[:space:]]*:?[[:space:]]*/, "", desc)
+      suffix="(" secret ")"
+      if (length(desc) < length(suffix)) next
+      if (substr(desc, length(desc) - length(suffix) + 1) != suffix) next
+      label=substr(desc, 1, length(desc) - length(suffix))
+      if (label == env || index(label, env "(") == 1) { print peer; exit }
+    }' <<<"$content"
+}
+
+mark_env_peer() {
+  local peer="$1"
+  [[ -n "$peer" ]] || return 0
+  ENV_PEERS["$peer"]=1
+  CHOSEN["$peer"]=1
 }
 
 run_allocation() {
   local assigned_content line n peer
-  local -A TAKEN=() CHOSEN=()
+  local -A TAKEN=() CHOSEN=() ENV_PEERS=()
   local tf="" wg0="" wg1="" reused="false" format="mosip"
+  local record_tf="false" record_wg0="false" record_wg1="false"
 
   assigned_content="$(cat "$ASSIGNED_FILE" 2>/dev/null || true)"
   assigned_content="${assigned_content//$'\r'/}"
@@ -384,44 +434,21 @@ run_allocation() {
         parse_assigned_line "$line" || continue
         [[ "$PARSED_LABEL" == "$ENV_NAME" ]] && echo "$PARSED_PEER"
       done <<<"$assigned_content" | sort -t r -k2 -n)
-      if [[ ${#colon_reused[@]} -ge 3 ]]; then
-        tf="${colon_reused[0]}"; wg0="${colon_reused[1]}"; wg1="${colon_reused[2]}"
-        reused="true"
-      fi
+      tf="${colon_reused[0]:-}"
+      wg0="${colon_reused[1]:-}"
+      wg1="${colon_reused[2]:-}"
+      mark_env_peer "$tf"
+      mark_env_peer "$wg0"
+      mark_env_peer "$wg1"
+      [[ -n "$tf" && -n "$wg0" && -n "$wg1" ]] && reused="true"
     else
-      tf="$(awk -v env="$ENV_NAME" -v secret="TF_WG_CONFIG" '
-        $1 ~ /^peer[0-9]+:?$/ {
-          peer=$1; sub(/:$/, "", peer)
-          desc=$0; sub(/^[[:space:]]*peer[0-9]+[[:space:]]*:?[[:space:]]*/, "", desc)
-          suffix="(" secret ")"
-          if (length(desc) < length(suffix)) next
-          if (substr(desc, length(desc) - length(suffix) + 1) != suffix) next
-          label=substr(desc, 1, length(desc) - length(suffix))
-          if (label == env || index(label, env "(") == 1) { print peer; exit }
-        }' <<<"$assigned_content")"
-      wg0="$(awk -v env="$ENV_NAME" -v secret="CLUSTER_WIREGUARD_WG0" '
-        $1 ~ /^peer[0-9]+:?$/ {
-          peer=$1; sub(/:$/, "", peer)
-          desc=$0; sub(/^[[:space:]]*peer[0-9]+[[:space:]]*:?[[:space:]]*/, "", desc)
-          suffix="(" secret ")"
-          if (length(desc) < length(suffix)) next
-          if (substr(desc, length(desc) - length(suffix) + 1) != suffix) next
-          label=substr(desc, 1, length(desc) - length(suffix))
-          if (label == env || index(label, env "(") == 1) { print peer; exit }
-        }' <<<"$assigned_content")"
-      wg1="$(awk -v env="$ENV_NAME" -v secret="CLUSTER_WIREGUARD_WG1" '
-        $1 ~ /^peer[0-9]+:?$/ {
-          peer=$1; sub(/:$/, "", peer)
-          desc=$0; sub(/^[[:space:]]*peer[0-9]+[[:space:]]*:?[[:space:]]*/, "", desc)
-          suffix="(" secret ")"
-          if (length(desc) < length(suffix)) next
-          if (substr(desc, length(desc) - length(suffix) + 1) != suffix) next
-          label=substr(desc, 1, length(desc) - length(suffix))
-          if (label == env || index(label, env "(") == 1) { print peer; exit }
-        }' <<<"$assigned_content")"
-      if [[ -n "$tf" && -n "$wg0" && -n "$wg1" ]]; then
-        reused="true"
-      fi
+      tf="$(mosip_peer_for_secret TF_WG_CONFIG "$assigned_content")"
+      wg0="$(mosip_peer_for_secret CLUSTER_WIREGUARD_WG0 "$assigned_content")"
+      wg1="$(mosip_peer_for_secret CLUSTER_WIREGUARD_WG1 "$assigned_content")"
+      mark_env_peer "$tf"
+      mark_env_peer "$wg0"
+      mark_env_peer "$wg1"
+      [[ -n "$tf" && -n "$wg0" && -n "$wg1" ]] && reused="true"
     fi
   fi
 
@@ -449,31 +476,61 @@ run_allocation() {
   fi
 
   for peer in "$tf" "$wg0" "$wg1"; do
-    [[ "$reused" != "true" && -n "${TAKEN[$peer]:-}" ]] \
+    [[ -n "${TAKEN[$peer]:-}" && -z "${ENV_PEERS[$peer]:-}" ]] \
       && { echo "ERROR: $peer already assigned in $ASSIGNED_FILE" >&2; return 1; }
     [[ "$peer" =~ ^peer[0-9]+$ ]] || { echo "ERROR: invalid peer id $peer" >&2; return 1; }
     n="${peer#peer}"
-    ensure_peer_conf "$n" || true
+    ensure_peer_conf "$n" || { echo "ERROR: failed creating $peer" >&2; return 1; }
   done
 
   [[ "$tf" != "$wg0" && "$tf" != "$wg1" && "$wg0" != "$wg1" ]] \
     || { echo "ERROR: peers must be distinct (tf=$tf wg0=$wg0 wg1=$wg1)" >&2; return 1; }
 
-  if [[ "$reused" != "true" && "$DRY_RUN" != "true" ]]; then
+  [[ -z "${ENV_PEERS[$tf]:-}"  ]] && record_tf="true"
+  [[ -z "${ENV_PEERS[$wg0]:-}" ]] && record_wg0="true"
+  [[ -z "${ENV_PEERS[$wg1]:-}" ]] && record_wg1="true"
+
+  if [[ "$DRY_RUN" != "true" ]]; then
     if [[ "$format" == "colon" ]]; then
-      record_assignment "$tf"  "$ENV_NAME" "$format" "$ASSIGNED_FILE"
-      record_assignment "$wg0" "$ENV_NAME" "$format" "$ASSIGNED_FILE"
-      record_assignment "$wg1" "$ENV_NAME" "$format" "$ASSIGNED_FILE"
+      [[ "$record_tf" == "true"  ]] && record_assignment "$tf"  "$ENV_NAME" "$format" "$ASSIGNED_FILE"
+      [[ "$record_wg0" == "true" ]] && record_assignment "$wg0" "$ENV_NAME" "$format" "$ASSIGNED_FILE"
+      [[ "$record_wg1" == "true" ]] && record_assignment "$wg1" "$ENV_NAME" "$format" "$ASSIGNED_FILE"
     else
-      record_assignment "$tf"  "${LABEL}(TF_WG_CONFIG)" "$format" "$ASSIGNED_FILE"
-      record_assignment "$wg0" "${LABEL}(CLUSTER_WIREGUARD_WG0)" "$format" "$ASSIGNED_FILE"
-      record_assignment "$wg1" "${LABEL}(CLUSTER_WIREGUARD_WG1)" "$format" "$ASSIGNED_FILE"
+      [[ "$record_tf" == "true"  ]] && record_assignment "$tf"  "${LABEL}(TF_WG_CONFIG)" "$format" "$ASSIGNED_FILE"
+      [[ "$record_wg0" == "true" ]] && record_assignment "$wg0" "${LABEL}(CLUSTER_WIREGUARD_WG0)" "$format" "$ASSIGNED_FILE"
+      [[ "$record_wg1" == "true" ]] && record_assignment "$wg1" "${LABEL}(CLUSTER_WIREGUARD_WG1)" "$format" "$ASSIGNED_FILE"
     fi
   fi
 
-  printf 'ASSIGNED_FORMAT=%s\nREUSED=%s\nTF_PEER=%s\nWG0_PEER=%s\nWG1_PEER=%s\n' \
-    "$format" "$reused" "$tf" "$wg0" "$wg1"
+  printf 'ASSIGNED_FORMAT=%s\nREUSED=%s\nTF_PEER=%s\nWG0_PEER=%s\nWG1_PEER=%s\nRECORD_TF=%s\nRECORD_WG0=%s\nRECORD_WG1=%s\n' \
+    "$format" "$reused" "$tf" "$wg0" "$wg1" "$record_tf" "$record_wg0" "$record_wg1"
 }
+
+exec 9>"$LOCK_FILE"
+if ! flock -w 120 9; then
+  echo "ERROR: timed out waiting for allocation lock ($LOCK_FILE)" >&2
+  exit 1
+fi
+run_allocation
+REMOTE_ATOMIC_ALLOCATE
+}
+
+atomic_rollback_assignments() {
+  local record_tf="$1" record_wg0="$2" record_wg1="$3"
+  [[ "$record_tf" == "true" || "$record_wg0" == "true" || "$record_wg1" == "true" ]] || return 0
+  ssh_cmd bash -s \
+    "$ASSIGNED_FILE" "$ASSIGN_LOCK_FILE" "$TF_PEER" "$WG0_PEER" "$WG1_PEER" "$record_tf" "$record_wg0" "$record_wg1" \
+    <<'REMOTE_ROLLBACK_ASSIGNMENTS'
+set -euo pipefail
+
+ASSIGNED_FILE="$1"
+LOCK_FILE="$2"
+TF_PEER="$3"
+WG0_PEER="$4"
+WG1_PEER="$5"
+RECORD_TF="$6"
+RECORD_WG0="$7"
+RECORD_WG1="$8"
 
 exec 9>"$LOCK_FILE" || { echo "ERROR: cannot create allocation lock ($LOCK_FILE)" >&2; exit 1; }
 if ! flock -w 120 9; then
@@ -485,8 +542,19 @@ if [[ ! -w "$ASSIGNED_FILE" && ! -w "$wg_dir" ]]; then
   echo "ERROR: cannot write $ASSIGNED_FILE (check ownership/permissions on $wg_dir)" >&2
   exit 1
 fi
-run_allocation
-REMOTE_ATOMIC_ALLOCATE
+
+remove_peer_line() {
+  local peer="$1" file="$2" tmp
+  tmp="$(mktemp)"
+  awk -v p="$peer" '$1 !~ ("^" p ":?$")' "$file" > "$tmp"
+  cat "$tmp" > "$file"
+  rm -f "$tmp"
+}
+
+[[ "$RECORD_TF" == "true"  ]] && remove_peer_line "$TF_PEER" "$ASSIGNED_FILE"
+[[ "$RECORD_WG0" == "true" ]] && remove_peer_line "$WG0_PEER" "$ASSIGNED_FILE"
+[[ "$RECORD_WG1" == "true" ]] && remove_peer_line "$WG1_PEER" "$ASSIGNED_FILE"
+REMOTE_ROLLBACK_ASSIGNMENTS
 }
 
 log "Allocating peers on jumpserver under flock ($ASSIGN_LOCK_FILE) ..."
@@ -496,6 +564,9 @@ REUSED="false"
 TF_PEER=""
 WG0_PEER=""
 WG1_PEER=""
+RECORD_TF="false"
+RECORD_WG0="false"
+RECORD_WG1="false"
 while IFS= read -r line; do
   [[ "$line" == *=* ]] || continue
   case "${line%%=*}" in
@@ -504,6 +575,9 @@ while IFS= read -r line; do
     TF_PEER)         TF_PEER="${line#*=}" ;;
     WG0_PEER)        WG0_PEER="${line#*=}" ;;
     WG1_PEER)        WG1_PEER="${line#*=}" ;;
+    RECORD_TF)       RECORD_TF="${line#*=}" ;;
+    RECORD_WG0)      RECORD_WG0="${line#*=}" ;;
+    RECORD_WG1)      RECORD_WG1="${line#*=}" ;;
   esac
 done <<<"$ALLOC_RESULT"
 [[ -n "$TF_PEER" && -n "$WG0_PEER" && -n "$WG1_PEER" ]] \
@@ -511,6 +585,8 @@ done <<<"$ALLOC_RESULT"
 
 if [[ "$REUSED" == "true" ]]; then
   log "Reusing existing allocation for $ENV_NAME: TF=$TF_PEER WG0=$WG0_PEER WG1=$WG1_PEER"
+elif [[ "$RECORD_TF" != "true" || "$RECORD_WG0" != "true" || "$RECORD_WG1" != "true" ]]; then
+  log "Resuming partial allocation for $ENV_NAME: TF=$TF_PEER WG0=$WG0_PEER WG1=$WG1_PEER"
 elif [[ "$ASSIGNED_FORMAT" == "colon" ]]; then
   log "Detected assigned.txt colon format (peerN: username)"
 fi
@@ -519,9 +595,13 @@ log "Allocation -> TF_WG_CONFIG=$TF_PEER | CLUSTER_WIREGUARD_WG0=$WG0_PEER | CLU
 
 # ---- Fetch + transform each peer conf --------------------------------------
 transform_conf() {
-  # stdin: raw peer conf -> stdout: DNS removed, AllowedIPs replaced
-  sed -e '/^[[:space:]]*DNS[[:space:]]*=/d' \
-      -e "s#^[[:space:]]*AllowedIPs[[:space:]]*=.*#AllowedIPs = ${ALLOWED_IPS}#"
+  # stdin: raw peer conf -> stdout: DNS removed, [Peer] AllowedIPs replaced
+  awk -v ips="$ALLOWED_IPS" '
+    /^\[Peer\]/ { peer=1; print; next }
+    peer && /^[[:space:]]*AllowedIPs[[:space:]]*=/ { print "AllowedIPs = " ips; next }
+    /^[[:space:]]*DNS[[:space:]]*=/ { next }
+    { print }
+  '
 }
 
 fetch_and_transform() {
@@ -545,15 +625,15 @@ if [[ "$DRY_RUN" != "true" ]]; then
 fi
 
 if [[ "$DRY_RUN" == "true" ]]; then
-  log "DRY RUN - would update $ASSIGNED_FILE:"
+  log "DRY RUN - would update $ASSIGNED_FILE under allocation lock:"
   if [[ "$ASSIGNED_FORMAT" == "colon" ]]; then
-    log "    $TF_PEER: $ENV_NAME"
-    log "    $WG0_PEER: $ENV_NAME"
-    log "    $WG1_PEER: $ENV_NAME"
+    [[ "$RECORD_TF" == "true"  ]] && log "    $TF_PEER: $ENV_NAME"
+    [[ "$RECORD_WG0" == "true" ]] && log "    $WG0_PEER: $ENV_NAME"
+    [[ "$RECORD_WG1" == "true" ]] && log "    $WG1_PEER: $ENV_NAME"
   else
-    log "    $TF_PEER  ${LABEL}(TF_WG_CONFIG)"
-    log "    $WG0_PEER ${LABEL}(CLUSTER_WIREGUARD_WG0)"
-    log "    $WG1_PEER ${LABEL}(CLUSTER_WIREGUARD_WG1)"
+    [[ "$RECORD_TF" == "true"  ]] && log "    $TF_PEER  ${LABEL}(TF_WG_CONFIG)"
+    [[ "$RECORD_WG0" == "true" ]] && log "    $WG0_PEER ${LABEL}(CLUSTER_WIREGUARD_WG0)"
+    [[ "$RECORD_WG1" == "true" ]] && log "    $WG1_PEER ${LABEL}(CLUSTER_WIREGUARD_WG1)"
   fi
   log "DRY RUN - would create env '$ENV_NAME' and set 3 secrets (values not shown)."
   if grep -q '^AllowedIPs' <<<"$TF_CONF" 2>/dev/null; then
@@ -566,23 +646,40 @@ fi
 log "Ensuring GitHub environment '$ENV_NAME' exists ..."
 ENV_NAME_ENC="$(urlencode "$ENV_NAME")"
 gh api --method PUT -H "Accept: application/vnd.github+json" \
-  "repos/${REPO}/environments/${ENV_NAME_ENC}" >/dev/null
+  "repos/${REPO}/environments/${ENV_NAME_ENC}" >/dev/null \
+  || die "Failed creating environment '$ENV_NAME' in $REPO"
 
 log "Publishing environment secrets ..."
 PEER_CONFS=("$TF_CONF" "$WG0_CONF" "$WG1_CONF")
+PUBLISHED_SECRETS=0
 for i in "${!SECRET_NAMES[@]}"; do
-  printf '%s' "${PEER_CONFS[$i]}" \
-    | gh secret set "${SECRET_NAMES[$i]}" --env "$ENV_NAME" --repo "$REPO" --body -
+  if printf '%s' "${PEER_CONFS[$i]}" \
+    | gh secret set "${SECRET_NAMES[$i]}" --env "$ENV_NAME" --repo "$REPO" --body -; then
+    PUBLISHED_SECRETS=$((PUBLISHED_SECRETS + 1))
+    log "Published ${SECRET_NAMES[$i]}"
+  else
+    err "Failed to publish ${SECRET_NAMES[$i]} (${PUBLISHED_SECRETS}/3 succeeded)"
+    err "Rolling back newly recorded assignments in $ASSIGNED_FILE ..."
+    atomic_rollback_assignments "$RECORD_TF" "$RECORD_WG0" "$RECORD_WG1" \
+      || err "Rollback failed; please fix $ASSIGNED_FILE manually for peers TF=$TF_PEER WG0=$WG0_PEER WG1=$WG1_PEER"
+    exit 1
+  fi
 done
 
 # ---- Mirror allocation into the repo tracker (for visibility/PR history) ----
 if [[ ! -f "$ALLOCATION_FILE" ]]; then
   printf 'env_name\ttf_peer\twg0_peer\twg1_peer\tallocated_at\n' > "$ALLOCATION_FILE"
 fi
+exec 8>"${ALLOCATION_FILE}.lock"
+if ! flock -w 30 8; then
+  die "Timed out waiting to update repo tracker lock ${ALLOCATION_FILE}.lock"
+fi
 TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
 awk -F '\t' -v env="$ENV_NAME" 'NR == 1 || $1 != env' "$ALLOCATION_FILE" > "$TMP"
 printf '%s\t%s\t%s\t%s\t%s\n' "$ENV_NAME" "$TF_PEER" "$WG0_PEER" "$WG1_PEER" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$TMP"
 mv "$TMP" "$ALLOCATION_FILE"
+trap - EXIT
 
 log "Done. Environment '$ENV_NAME' onboarded with peers TF=$TF_PEER WG0=$WG0_PEER WG1=$WG1_PEER."
 log "Server tracker: $ASSIGNED_FILE | repo tracker: $ALLOCATION_FILE (commit it)."

--- a/.github/scripts/wg-onboard.sh
+++ b/.github/scripts/wg-onboard.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+#
+# wg-onboard.sh - Self-service WireGuard onboarding for a new environment.
+#
+# Automates the manual jumpserver process:
+#   1. SSH into the WireGuard VM.
+#   2. cd into the WireGuard env dir (default /home/ubuntu/wireguard_env_2026).
+#   3. Allocate the next 3 free peers (assigned.txt is the source of truth) and
+#      append them for the new environment - one peer per secret:
+#         peerA <env>(TF_WG_CONFIG)
+#         peerB <env>(CLUSTER_WIREGUARD_WG0)
+#         peerC <env>(CLUSTER_WIREGUARD_WG1)
+#   4. For each peer's client conf (config/peerN/peerN.conf):
+#         - remove the `DNS = ...` line
+#         - set `AllowedIPs = 172.31.0.0/16`
+#   5. Publish the 3 transformed confs as GitHub *environment* secrets
+#      (TF_WG_CONFIG, CLUSTER_WIREGUARD_WG0, CLUSTER_WIREGUARD_WG1) on the
+#      environment whose name == the branch/env name.
+#
+# Three distinct peers are used because the Helmsman wg0/wg1 matrix jobs run
+# concurrently and Terraform uses its own peer too.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ALLOCATION_FILE="${ALLOCATION_FILE:-$SCRIPT_DIR/wg-peer-allocation.tsv}"
+
+# Defaults (override via flags or env vars)
+SSH_USER="${SSH_USER:-ubuntu}"
+SSH_KEY="${SSH_KEY:-}"
+JUMPSERVER_HOST="${JUMPSERVER_HOST:-}"
+ENV_NAME="${ENV_NAME:-}"
+REPO="${REPO:-}"
+WG_DIR="${WG_DIR:-/home/ubuntu/wireguard_env_2026}"
+ALLOWED_IPS="${ALLOWED_IPS:-172.31.0.0/16}"
+TICKET="${TICKET:-}"
+TF_PEER=""
+WG0_PEER=""
+WG1_PEER=""
+DRY_RUN="false"
+
+# Secret name -> peer variable mapping is fixed in this order.
+SECRET_NAMES=(TF_WG_CONFIG CLUSTER_WIREGUARD_WG0 CLUSTER_WIREGUARD_WG1)
+
+usage() {
+  cat <<'EOF'
+Usage: wg-onboard.sh --env <name> --host <jumpserver_ip> --ssh-key <path> [options]
+
+Required:
+  --env <name>          Environment / branch name (also the label in assigned.txt
+                        and the GitHub environment to target)
+  --host <ip|dns>       Jumpserver public IP or DNS (SSH reachable)
+  --ssh-key <path>      Path to the private key for ubuntu@jumpserver
+
+Optional:
+  --repo <owner/repo>   GitHub repo (default: inferred from `gh repo view`)
+  --ticket <id>         Ticket id to record in assigned.txt, e.g. DSD-10264
+  --wg-dir <path>       WireGuard env dir on the VM (default: /home/ubuntu/wireguard_env_2026)
+  --allowed-ips <cidr>  AllowedIPs to set in each conf (default: 172.31.0.0/16)
+  --tf-peer  <peerN>    Force the TF_WG_CONFIG peer          (default: next free)
+  --wg0-peer <peerN>    Force the CLUSTER_WIREGUARD_WG0 peer (default: next free)
+  --wg1-peer <peerN>    Force the CLUSTER_WIREGUARD_WG1 peer (default: next free)
+  --dry-run             Resolve + transform + print actions without writing anything
+  -h, --help            Show this help
+
+Requires: gh (authenticated with a token that can write environment secrets), ssh.
+EOF
+}
+
+log()  { echo "[wg-onboard] $*"; }
+err()  { echo "[wg-onboard][ERROR] $*" >&2; }
+die()  { err "$*"; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env)         ENV_NAME="$2"; shift 2 ;;
+    --host)        JUMPSERVER_HOST="$2"; shift 2 ;;
+    --ssh-key)     SSH_KEY="$2"; shift 2 ;;
+    --repo)        REPO="$2"; shift 2 ;;
+    --ticket)      TICKET="$2"; shift 2 ;;
+    --wg-dir)      WG_DIR="$2"; shift 2 ;;
+    --allowed-ips) ALLOWED_IPS="$2"; shift 2 ;;
+    --tf-peer)     TF_PEER="$2"; shift 2 ;;
+    --wg0-peer)    WG0_PEER="$2"; shift 2 ;;
+    --wg1-peer)    WG1_PEER="$2"; shift 2 ;;
+    --dry-run)     DRY_RUN="true"; shift ;;
+    -h|--help)     usage; exit 0 ;;
+    *)             die "Unknown argument: $1 (use --help)" ;;
+  esac
+done
+
+[[ -n "$ENV_NAME" ]]        || die "--env is required"
+[[ -n "$JUMPSERVER_HOST" ]] || die "--host is required"
+[[ -n "$SSH_KEY" ]]         || die "--ssh-key is required"
+[[ -f "$SSH_KEY" ]]         || die "ssh key not found: $SSH_KEY"
+command -v gh  >/dev/null 2>&1 || die "gh CLI is required"
+command -v ssh >/dev/null 2>&1 || die "ssh is required"
+
+if [[ -z "$REPO" ]]; then
+  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
+  [[ -n "$REPO" ]] || die "Could not infer repo; pass --repo <owner/repo>"
+fi
+
+CONFIG_DIR="$WG_DIR/config"
+ASSIGNED_FILE="$WG_DIR/assigned.txt"
+LABEL="$ENV_NAME"
+[[ -n "$TICKET" ]] && LABEL="${ENV_NAME}(${TICKET})"
+
+log "Target repo: $REPO"
+log "Target environment: $ENV_NAME (label: $LABEL)"
+log "WireGuard dir: $WG_DIR | AllowedIPs: $ALLOWED_IPS"
+
+ssh_cmd() {
+  ssh -i "$SSH_KEY" -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
+    "${SSH_USER}@${JUMPSERVER_HOST}" "$@"
+}
+
+# ---- Read current state from the jumpserver --------------------------------
+log "Reading assigned.txt and peer inventory from jumpserver ${JUMPSERVER_HOST} ..."
+ASSIGNED_CONTENT="$(ssh_cmd "cat '$ASSIGNED_FILE' 2>/dev/null" || true)"
+PEER_LISTING="$(ssh_cmd "ls '$CONFIG_DIR'" 2>/dev/null || true)"
+[[ -n "$PEER_LISTING" ]] || die "Could not list $CONFIG_DIR on jumpserver (check --wg-dir / connectivity)"
+
+# Peers that physically exist as client configs
+mapfile -t EXISTING_PEERS < <(printf '%s\n' "$PEER_LISTING" | grep -E '^peer[0-9]+$' | sort -t r -k2 -n)
+[[ ${#EXISTING_PEERS[@]} -gt 0 ]] || die "No peer directories found under $CONFIG_DIR"
+
+# Peers already taken (a peerN line in assigned.txt that has a non-empty label)
+declare -A TAKEN=()
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  peer="$(awk '{print $1}' <<<"$line")"
+  [[ "$peer" =~ ^peer[0-9]+$ ]] || continue
+  rest="$(awk '{$1=""; sub(/^ +/,""); print}' <<<"$line")"
+  [[ -n "$rest" ]] && TAKEN["$peer"]=1
+done <<<"$ASSIGNED_CONTENT"
+
+# ---- Reuse existing allocation for this env, if present (idempotent) -------
+find_assigned_peer() {
+  local secret="$1"
+  awk -v env="$ENV_NAME" -v sec="($secret)" '
+    $1 ~ /^peer[0-9]+$/ {
+      desc=substr($0, index($0,$2))
+      if (index(desc, env) && index(desc, sec)) { print $1; exit }
+    }' <<<"$ASSIGNED_CONTENT"
+}
+
+REUSED="false"
+if [[ -z "$TF_PEER" && -z "$WG0_PEER" && -z "$WG1_PEER" ]]; then
+  rtf="$(find_assigned_peer TF_WG_CONFIG)"
+  rwg0="$(find_assigned_peer CLUSTER_WIREGUARD_WG0)"
+  rwg1="$(find_assigned_peer CLUSTER_WIREGUARD_WG1)"
+  if [[ -n "$rtf" && -n "$rwg0" && -n "$rwg1" ]]; then
+    TF_PEER="$rtf"; WG0_PEER="$rwg0"; WG1_PEER="$rwg1"; REUSED="true"
+    log "Reusing existing allocation for $ENV_NAME: TF=$TF_PEER WG0=$WG0_PEER WG1=$WG1_PEER"
+  fi
+fi
+
+# ---- Allocate next free peers for any not explicitly set / reused ----------
+# Build ordered list of free peers (exist in config, not taken, not already chosen here)
+declare -A CHOSEN=()
+[[ -n "$TF_PEER"  ]] && CHOSEN["$TF_PEER"]=1
+[[ -n "$WG0_PEER" ]] && CHOSEN["$WG0_PEER"]=1
+[[ -n "$WG1_PEER" ]] && CHOSEN["$WG1_PEER"]=1
+
+next_free_peer() {
+  local p
+  for p in "${EXISTING_PEERS[@]}"; do
+    if [[ -z "${TAKEN[$p]:-}" && -z "${CHOSEN[$p]:-}" ]]; then
+      echo "$p"; return 0
+    fi
+  done
+  return 1
+}
+
+if [[ "$REUSED" != "true" ]]; then
+  if [[ -z "$TF_PEER"  ]]; then TF_PEER="$(next_free_peer)"  || die "No free peers left"; CHOSEN["$TF_PEER"]=1;  fi
+  if [[ -z "$WG0_PEER" ]]; then WG0_PEER="$(next_free_peer)" || die "No free peers left"; CHOSEN["$WG0_PEER"]=1; fi
+  if [[ -z "$WG1_PEER" ]]; then WG1_PEER="$(next_free_peer)" || die "No free peers left"; CHOSEN["$WG1_PEER"]=1; fi
+fi
+
+# sanity: all three distinct and exist
+for p in "$TF_PEER" "$WG0_PEER" "$WG1_PEER"; do
+  printf '%s\n' "${EXISTING_PEERS[@]}" | grep -qx "$p" || die "Peer $p does not exist under $CONFIG_DIR"
+done
+[[ "$TF_PEER" != "$WG0_PEER" && "$TF_PEER" != "$WG1_PEER" && "$WG0_PEER" != "$WG1_PEER" ]] \
+  || die "Peers must be distinct (TF=$TF_PEER WG0=$WG0_PEER WG1=$WG1_PEER)"
+
+log "Allocation -> TF_WG_CONFIG=$TF_PEER | CLUSTER_WIREGUARD_WG0=$WG0_PEER | CLUSTER_WIREGUARD_WG1=$WG1_PEER"
+
+# ---- Fetch + transform each peer conf --------------------------------------
+transform_conf() {
+  # stdin: raw peer conf -> stdout: DNS removed, AllowedIPs replaced
+  sed -e '/^[[:space:]]*DNS[[:space:]]*=/d' \
+      -e "s#^[[:space:]]*AllowedIPs[[:space:]]*=.*#AllowedIPs = ${ALLOWED_IPS}#"
+}
+
+fetch_and_transform() {
+  local peer="$1" raw
+  raw="$(ssh_cmd "cat '$CONFIG_DIR/$peer/$peer.conf' 2>/dev/null || sudo cat '$CONFIG_DIR/$peer/$peer.conf'" 2>/dev/null || true)"
+  [[ -n "$raw" ]] || die "Could not read $CONFIG_DIR/$peer/$peer.conf"
+  grep -q '^[[:space:]]*AllowedIPs' <<<"$raw" || die "$peer.conf has no AllowedIPs line"
+  transform_conf <<<"$raw"
+}
+
+log "Fetching and transforming peer configs ..."
+TF_CONF="$(fetch_and_transform "$TF_PEER")"
+WG0_CONF="$(fetch_and_transform "$WG0_PEER")"
+WG1_CONF="$(fetch_and_transform "$WG1_PEER")"
+log "Transformed: stripped DNS, set AllowedIPs=${ALLOWED_IPS} on all three confs."
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  log "DRY RUN - would append to $ASSIGNED_FILE:"
+  log "    $TF_PEER  ${LABEL}(TF_WG_CONFIG)"
+  log "    $WG0_PEER ${LABEL}(CLUSTER_WIREGUARD_WG0)"
+  log "    $WG1_PEER ${LABEL}(CLUSTER_WIREGUARD_WG1)"
+  log "DRY RUN - would create env '$ENV_NAME' and set 3 secrets (values not shown)."
+  log "DRY RUN - AllowedIPs in each conf: $(grep -h '^AllowedIPs' <<<"$TF_CONF" | head -1)"
+  exit 0
+fi
+
+# ---- Append to assigned.txt on the jumpserver (skip if reused) -------------
+if [[ "$REUSED" != "true" ]]; then
+  log "Recording assignment in $ASSIGNED_FILE on jumpserver ..."
+  printf '%s %s(TF_WG_CONFIG)\n%s %s(CLUSTER_WIREGUARD_WG0)\n%s %s(CLUSTER_WIREGUARD_WG1)\n' \
+    "$TF_PEER" "$LABEL" "$WG0_PEER" "$LABEL" "$WG1_PEER" "$LABEL" \
+    | ssh_cmd "cat >> '$ASSIGNED_FILE'"
+fi
+
+# ---- Create the GitHub environment + publish the three secrets -------------
+log "Ensuring GitHub environment '$ENV_NAME' exists ..."
+gh api --method PUT -H "Accept: application/vnd.github+json" \
+  "repos/${REPO}/environments/${ENV_NAME}" >/dev/null
+
+log "Publishing environment secrets ..."
+printf '%s' "$TF_CONF"  | gh secret set TF_WG_CONFIG          --env "$ENV_NAME" --repo "$REPO" --body -
+printf '%s' "$WG0_CONF" | gh secret set CLUSTER_WIREGUARD_WG0 --env "$ENV_NAME" --repo "$REPO" --body -
+printf '%s' "$WG1_CONF" | gh secret set CLUSTER_WIREGUARD_WG1 --env "$ENV_NAME" --repo "$REPO" --body -
+
+# ---- Mirror allocation into the repo tracker (for visibility/PR history) ----
+if [[ ! -f "$ALLOCATION_FILE" ]]; then
+  printf 'env_name\ttf_peer\twg0_peer\twg1_peer\tallocated_at\n' > "$ALLOCATION_FILE"
+fi
+TMP="$(mktemp)"
+grep -vP "^${ENV_NAME}\t" "$ALLOCATION_FILE" > "$TMP" || true
+printf '%s\t%s\t%s\t%s\t%s\n' "$ENV_NAME" "$TF_PEER" "$WG0_PEER" "$WG1_PEER" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$TMP"
+mv "$TMP" "$ALLOCATION_FILE"
+
+log "Done. Environment '$ENV_NAME' onboarded with peers TF=$TF_PEER WG0=$WG0_PEER WG1=$WG1_PEER."
+log "Server tracker: $ASSIGNED_FILE | repo tracker: $ALLOCATION_FILE (commit it)."

--- a/.github/scripts/wg-onboard.sh
+++ b/.github/scripts/wg-onboard.sh
@@ -5,11 +5,13 @@
 # Automates the manual jumpserver process:
 #   1. SSH into the WireGuard VM.
 #   2. cd into the WireGuard env dir (default /home/ubuntu/wireguard_env_2026).
-#   3. Allocate the next 3 free peers (assigned.txt is the source of truth) and
-#      append them for the new environment - one peer per secret:
-#         peerA <env>(TF_WG_CONFIG)
-#         peerB <env>(CLUSTER_WIREGUARD_WG0)
-#         peerC <env>(CLUSTER_WIREGUARD_WG1)
+#   3. Allocate the next 3 free peers in the pool (peer1..peerN, filling gaps
+#      like peer66 before peer101). assigned.txt is the source of truth; if a
+#      peer directory or assigned.txt line is missing, create it on the VM first.
+#      Append assignments for the new environment - one peer per secret.
+#      Supports two assigned.txt layouts:
+#         peerN: username          (legacy colon format on /home/ubuntu)
+#         peerN env(SECRET_NAME)   (MOSIP per-secret format)
 #   4. For each peer's client conf (config/peerN/peerN.conf):
 #         - remove the `DNS = ...` line
 #         - set `AllowedIPs = 172.31.0.0/16`
@@ -37,6 +39,7 @@ TICKET="${TICKET:-}"
 TF_PEER=""
 WG0_PEER=""
 WG1_PEER=""
+MAX_PEERS=""
 DRY_RUN="false"
 
 # Secret name -> peer variable mapping is fixed in this order.
@@ -60,6 +63,7 @@ Optional:
   --tf-peer  <peerN>    Force the TF_WG_CONFIG peer          (default: next free)
   --wg0-peer <peerN>    Force the CLUSTER_WIREGUARD_WG0 peer (default: next free)
   --wg1-peer <peerN>    Force the CLUSTER_WIREGUARD_WG1 peer (default: next free)
+  --max-peers <n>       Peer pool size peer1..peerN (default: max(100, highest seen))
   --dry-run             Resolve + transform + print actions without writing anything
   -h, --help            Show this help
 
@@ -67,7 +71,7 @@ Requires: gh (authenticated with a token that can write environment secrets), ss
 EOF
 }
 
-log()  { echo "[wg-onboard] $*"; }
+log()  { echo "[wg-onboard] $*" >&2; }
 err()  { echo "[wg-onboard][ERROR] $*" >&2; }
 die()  { err "$*"; exit 1; }
 
@@ -83,6 +87,7 @@ while [[ $# -gt 0 ]]; do
     --tf-peer)     TF_PEER="$2"; shift 2 ;;
     --wg0-peer)    WG0_PEER="$2"; shift 2 ;;
     --wg1-peer)    WG1_PEER="$2"; shift 2 ;;
+    --max-peers)   MAX_PEERS="$2"; shift 2 ;;
     --dry-run)     DRY_RUN="true"; shift ;;
     -h|--help)     usage; exit 0 ;;
     *)             die "Unknown argument: $1 (use --help)" ;;
@@ -118,70 +123,338 @@ ssh_cmd() {
 # ---- Read current state from the jumpserver --------------------------------
 log "Reading assigned.txt and peer inventory from jumpserver ${JUMPSERVER_HOST} ..."
 ASSIGNED_CONTENT="$(ssh_cmd "cat '$ASSIGNED_FILE' 2>/dev/null" || true)"
+ASSIGNED_CONTENT="${ASSIGNED_CONTENT//$'\r'/}"
 PEER_LISTING="$(ssh_cmd "ls '$CONFIG_DIR'" 2>/dev/null || true)"
 [[ -n "$PEER_LISTING" ]] || die "Could not list $CONFIG_DIR on jumpserver (check --wg-dir / connectivity)"
 
+if [[ -z "$ASSIGNED_CONTENT" ]]; then
+  log "WARNING: $ASSIGNED_FILE is empty or unreadable over SSH — every peer will look FREE"
+else
+  assigned_lines="$(printf '%s\n' "$ASSIGNED_CONTENT" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')"
+  log "Loaded $ASSIGNED_FILE ($assigned_lines non-empty lines)"
+fi
+
 # Peers that physically exist as client configs
 mapfile -t EXISTING_PEERS < <(printf '%s\n' "$PEER_LISTING" | grep -E '^peer[0-9]+$' | sort -t r -k2 -n)
-[[ ${#EXISTING_PEERS[@]} -gt 0 ]] || die "No peer directories found under $CONFIG_DIR"
 
-# Peers already taken (a peerN line in assigned.txt that has a non-empty label)
+peer_number() {
+  local peer="$1"
+  [[ "$peer" =~ ^peer([0-9]+)$ ]] || return 1
+  echo "${BASH_REMATCH[1]}"
+}
+
+# Normalize "peer1" or "peer1:" from assigned.txt first field.
+normalize_peer_token() {
+  local token="${1//$'\r'/}"
+  token="${token%%:*}"
+  echo "$token"
+}
+
+# Parse one assigned.txt line -> PARSED_PEER / PARSED_LABEL (label empty = free).
+parse_assigned_line() {
+  local line="${1//$'\r'/}"
+  local peer rest
+  PARSED_PEER=""
+  PARSED_LABEL=""
+  [[ -z "${line//[[:space:]]/}" ]] && return 1
+  peer="$(normalize_peer_token "$(awk '{print $1}' <<<"$line")")"
+  [[ "$peer" =~ ^peer[0-9]+$ ]] || return 1
+  if [[ "$line" =~ ^peer[0-9]+:[[:space:]]*(.*)$ ]]; then
+    rest="${BASH_REMATCH[1]}"
+  else
+    rest="$(awk '{$1=""; sub(/^ +/,""); print}' <<<"$line")"
+  fi
+  rest="${rest//$'\r'/}"
+  PARSED_PEER="$peer"
+  PARSED_LABEL="$rest"
+  return 0
+}
+
+assigned_line_exists() {
+  local peer="$1"
+  grep -qE "^${peer}([[:space:]]|:)" <<<"$ASSIGNED_CONTENT"
+}
+
+highest_peer_number() {
+  local max=0 n peer
+  for peer in "${EXISTING_PEERS[@]}"; do
+    n="$(peer_number "$peer" || true)"
+    [[ -n "$n" && "$n" -gt "$max" ]] && max="$n"
+  done
+  while IFS= read -r line; do
+    parse_assigned_line "$line" || continue
+    n="$(peer_number "$PARSED_PEER" || true)"
+    [[ -n "$n" && "$n" -gt "$max" ]] && max="$n"
+  done <<<"$ASSIGNED_CONTENT"
+  echo "$max"
+}
+
+if [[ -z "$MAX_PEERS" ]]; then
+  detected_max="$(highest_peer_number)"
+  MAX_PEERS=$(( detected_max > 100 ? detected_max : 100 ))
+else
+  [[ "$MAX_PEERS" =~ ^[0-9]+$ && "$MAX_PEERS" -gt 0 ]] || die "--max-peers must be a positive integer"
+fi
+log "Peer pool: peer1..peer${MAX_PEERS} (gap-fill order, create missing peers on demand)"
+
+CAN_CREATE_PEERS="false"
+if [[ ${#EXISTING_PEERS[@]} -gt 0 ]] \
+  || ssh_cmd "test -f '$CONFIG_DIR/templates/peer.conf' || test -f '$CONFIG_DIR/peer1/peer1.conf'" 2>/dev/null; then
+  CAN_CREATE_PEERS="true"
+else
+  die "No peer directories or templates under $CONFIG_DIR (cannot create missing peers)"
+fi
+
+# Detect assigned.txt layout (colon vs per-secret MOSIP format).
+ASSIGNED_FORMAT="mosip"
+if grep -qE '^peer[0-9]+:' <<<"$ASSIGNED_CONTENT"; then
+  ASSIGNED_FORMAT="colon"
+  log "Detected assigned.txt colon format (peerN: username)"
+fi
+
+# Peers already taken: any peerN line with a non-empty label/username.
 declare -A TAKEN=()
 while IFS= read -r line; do
-  [[ -z "$line" ]] && continue
-  peer="$(awk '{print $1}' <<<"$line")"
-  [[ "$peer" =~ ^peer[0-9]+$ ]] || continue
-  rest="$(awk '{$1=""; sub(/^ +/,""); print}' <<<"$line")"
-  [[ -n "$rest" ]] && TAKEN["$peer"]=1
+  parse_assigned_line "$line" || continue
+  [[ -n "${PARSED_LABEL//[[:space:]]/}" ]] && TAKEN["$PARSED_PEER"]=1
 done <<<"$ASSIGNED_CONTENT"
+
+if [[ ${#TAKEN[@]} -gt 0 ]]; then
+  taken_sample="$(printf '%s\n' "${!TAKEN[@]}" | sort -t r -k2 -n | head -5 | paste -sd, -)"
+  log "Marked ${#TAKEN[@]} peers as taken in $ASSIGNED_FILE (e.g. ${taken_sample})"
+else
+  log "No taken peers parsed from $ASSIGNED_FILE — will start from peer1 unless gaps apply"
+fi
+
+peer_config_exists() {
+  local peer="$1"
+  ssh_cmd "test -f '$CONFIG_DIR/$peer/$peer.conf'" 2>/dev/null
+}
+
+ensure_assigned_entry() {
+  local peer="$1"
+  assigned_line_exists "$peer" && return 0
+  if [[ "$DRY_RUN" == "true" ]]; then
+    if [[ "$ASSIGNED_FORMAT" == "colon" ]]; then
+      log "DRY RUN - would append free slot to $ASSIGNED_FILE: ${peer}:"
+    else
+      log "DRY RUN - would append free slot to $ASSIGNED_FILE: ${peer}"
+    fi
+    return 0
+  fi
+  log "Adding free slot ${peer} to $ASSIGNED_FILE ..."
+  if [[ "$ASSIGNED_FORMAT" == "colon" ]]; then
+    printf '%s:\n' "$peer" | ssh_cmd "cat >> '$ASSIGNED_FILE'"
+    ASSIGNED_CONTENT+=$'\n'"${peer}:"
+  else
+    printf '%s \n' "$peer" | ssh_cmd "cat >> '$ASSIGNED_FILE'"
+    ASSIGNED_CONTENT+=$'\n'"${peer} "
+  fi
+}
+
+ensure_peer_exists() {
+  local peer="$1"
+  peer_config_exists "$peer" && return 0
+  [[ "$CAN_CREATE_PEERS" == "true" ]] || die "Peer $peer is missing under $CONFIG_DIR and cannot be created"
+  local peer_num
+  peer_num="$(peer_number "$peer")" || die "Invalid peer id: $peer"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log "DRY RUN - would create missing peer $peer on jumpserver"
+    ensure_assigned_entry "$peer"
+    return 0
+  fi
+
+  log "Creating missing peer $peer on jumpserver ..."
+  ssh_cmd "bash -s" "$peer_num" "$CONFIG_DIR" <<'REMOTE_CREATE_PEER'
+set -euo pipefail
+PEER_NUM="$1"
+CONFIG_DIR="$2"
+PEER_ID="peer${PEER_NUM}"
+
+if [[ -f "$CONFIG_DIR/$PEER_ID/$PEER_ID.conf" ]]; then
+  exit 0
+fi
+
+mapfile -t REF_DIRS < <(ls -d "$CONFIG_DIR"/peer[0-9]* 2>/dev/null | sort -t r -k2 -n)
+[[ ${#REF_DIRS[@]} -gt 0 ]] || { echo "No reference peer under $CONFIG_DIR" >&2; exit 1; }
+REF_DIR="${REF_DIRS[0]}"
+REF_ID="$(basename "$REF_DIR")"
+REF_CONF="$REF_DIR/$REF_ID.conf"
+[[ -f "$REF_CONF" ]] || { echo "Missing reference conf: $REF_CONF" >&2; exit 1; }
+
+INTERFACE="$(grep -m1 '^Address' "$REF_CONF" | awk '{print $NF}' | awk -F. '{print $1"."$2"."$3}')"
+ENDPOINT="$(grep -m1 '^Endpoint' "$REF_CONF" | awk '{print $NF}')"
+SERVER_PUBKEY="$(grep -m1 '^PublicKey' "$REF_CONF" | awk '{print $NF}')"
+PEERDNS="$(grep -m1 '^DNS' "$REF_CONF" | awk '{print $NF}')"
+[[ -n "$INTERFACE" && -n "$ENDPOINT" && -n "$SERVER_PUBKEY" ]] \
+  || { echo "Could not read reference WireGuard settings from $REF_CONF" >&2; exit 1; }
+[[ -n "$PEERDNS" ]] || PEERDNS="${INTERFACE}.1"
+
+C="$(docker ps --format '{{.Names}}' | grep -iE 'wireguard|wg' | head -1 || true)"
+[[ -n "$C" ]] || { echo "WireGuard docker container not found" >&2; exit 1; }
+
+mkdir -p "$CONFIG_DIR/$PEER_ID"
+umask 077
+docker exec "$C" wg genkey | tee "$CONFIG_DIR/$PEER_ID/privatekey-$PEER_ID" \
+  | docker exec -i "$C" wg pubkey > "$CONFIG_DIR/$PEER_ID/publickey-$PEER_ID"
+docker exec "$C" wg genpsk > "$CONFIG_DIR/$PEER_ID/presharedkey-$PEER_ID"
+
+CLIENT_IP=""
+for idx in $(seq 2 254); do
+  PROPOSED="${INTERFACE}.${idx}"
+  if ! grep -qR "${PROPOSED}" "$CONFIG_DIR"/peer*/*.conf 2>/dev/null; then
+    CLIENT_IP="$PROPOSED"
+    break
+  fi
+done
+[[ -n "$CLIENT_IP" ]] || { echo "No free client IP in ${INTERFACE}.0/24" >&2; exit 1; }
+
+PRIV="$(cat "$CONFIG_DIR/$PEER_ID/privatekey-$PEER_ID")"
+PSK="$(cat "$CONFIG_DIR/$PEER_ID/presharedkey-$PEER_ID")"
+PUB="$(cat "$CONFIG_DIR/$PEER_ID/publickey-$PEER_ID")"
+
+cat > "$CONFIG_DIR/$PEER_ID/$PEER_ID.conf" <<EOF
+[Interface]
+Address = ${CLIENT_IP}
+PrivateKey = ${PRIV}
+ListenPort = 51820
+DNS = ${PEERDNS}
+
+[Peer]
+PublicKey = ${SERVER_PUBKEY}
+PresharedKey = ${PSK}
+Endpoint = ${ENDPOINT}
+AllowedIPs = 0.0.0.0/0, ::/0
+EOF
+
+if [[ -f "$CONFIG_DIR/wg_confs/wg0.conf" ]]; then
+  WG_CONF="$CONFIG_DIR/wg_confs/wg0.conf"
+else
+  WG_CONF="$CONFIG_DIR/wg0.conf"
+fi
+
+cat >> "$WG_CONF" <<EOF
+
+[Peer]
+# ${PEER_ID}
+PublicKey = ${PUB}
+PresharedKey = ${PSK}
+AllowedIPs = ${CLIENT_IP}/32
+
+EOF
+
+docker exec "$C" wg set wg0 peer "$PUB" preshared-key "$PSK" allowed-ips "${CLIENT_IP}/32" \
+  || docker restart "$C" >/dev/null
+REMOTE_CREATE_PEER
+
+  ensure_assigned_entry "$peer"
+}
+
+record_peer_assignment() {
+  local peer="$1"
+  local assignment="$2"
+  ssh_cmd "bash -s" "$peer" "$assignment" "$ASSIGNED_FILE" "$ASSIGNED_FORMAT" <<'REMOTE_RECORD_ASSIGNMENT'
+set -euo pipefail
+peer="$1"
+assignment="$2"
+file="$3"
+format="$4"
+if [[ "$format" == "colon" ]]; then
+  line="${peer}: ${assignment}"
+  if grep -qE "^${peer}:" "$file"; then
+    sed -i "s|^${peer}:.*|${line}|" "$file"
+  elif grep -qE "^${peer}([[:space:]]|$)" "$file"; then
+    sed -i "s|^${peer}.*|${line}|" "$file"
+  else
+    printf '%s\n' "$line" >> "$file"
+  fi
+else
+  line="${peer} ${assignment}"
+  if grep -qE "^${peer}([[:space:]]|$)" "$file"; then
+    sed -i "s|^${peer}.*|${line}|" "$file"
+  else
+    printf '%s\n' "$line" >> "$file"
+  fi
+fi
+REMOTE_RECORD_ASSIGNMENT
+}
 
 # ---- Reuse existing allocation for this env, if present (idempotent) -------
 find_assigned_peer() {
   local secret="$1"
   awk -v env="$ENV_NAME" -v sec="($secret)" '
-    $1 ~ /^peer[0-9]+$/ {
+    $1 ~ /^peer[0-9]+:?$/ {
+      peer=$1
+      sub(/:$/, "", peer)
       desc=substr($0, index($0,$2))
-      if (index(desc, env) && index(desc, sec)) { print $1; exit }
+      if (index(desc, env) && index(desc, sec)) { print peer; exit }
     }' <<<"$ASSIGNED_CONTENT"
+}
+
+find_colon_env_peers() {
+  local line
+  while IFS= read -r line; do
+    parse_assigned_line "$line" || continue
+    [[ "$PARSED_LABEL" == "$ENV_NAME" ]] && echo "$PARSED_PEER"
+  done <<<"$ASSIGNED_CONTENT"
 }
 
 REUSED="false"
 if [[ -z "$TF_PEER" && -z "$WG0_PEER" && -z "$WG1_PEER" ]]; then
-  rtf="$(find_assigned_peer TF_WG_CONFIG)"
-  rwg0="$(find_assigned_peer CLUSTER_WIREGUARD_WG0)"
-  rwg1="$(find_assigned_peer CLUSTER_WIREGUARD_WG1)"
-  if [[ -n "$rtf" && -n "$rwg0" && -n "$rwg1" ]]; then
-    TF_PEER="$rtf"; WG0_PEER="$rwg0"; WG1_PEER="$rwg1"; REUSED="true"
-    log "Reusing existing allocation for $ENV_NAME: TF=$TF_PEER WG0=$WG0_PEER WG1=$WG1_PEER"
+  if [[ "$ASSIGNED_FORMAT" == "colon" ]]; then
+    mapfile -t COLON_REUSED < <(find_colon_env_peers | sort -t r -k2 -n)
+    if [[ ${#COLON_REUSED[@]} -ge 3 ]]; then
+      TF_PEER="${COLON_REUSED[0]}"; WG0_PEER="${COLON_REUSED[1]}"; WG1_PEER="${COLON_REUSED[2]}"
+      REUSED="true"
+      log "Reusing existing colon-format allocation for $ENV_NAME: TF=$TF_PEER WG0=$WG0_PEER WG1=$WG1_PEER"
+    fi
+  else
+    rtf="$(find_assigned_peer TF_WG_CONFIG)"
+    rwg0="$(find_assigned_peer CLUSTER_WIREGUARD_WG0)"
+    rwg1="$(find_assigned_peer CLUSTER_WIREGUARD_WG1)"
+    if [[ -n "$rtf" && -n "$rwg0" && -n "$rwg1" ]]; then
+      TF_PEER="$rtf"; WG0_PEER="$rwg0"; WG1_PEER="$rwg1"; REUSED="true"
+      log "Reusing existing allocation for $ENV_NAME: TF=$TF_PEER WG0=$WG0_PEER WG1=$WG1_PEER"
+    fi
   fi
 fi
 
 # ---- Allocate next free peers for any not explicitly set / reused ----------
-# Build ordered list of free peers (exist in config, not taken, not already chosen here)
+# Walk peer1..peerMAX in numeric order so gaps (e.g. peer66) are reused first.
 declare -A CHOSEN=()
 [[ -n "$TF_PEER"  ]] && CHOSEN["$TF_PEER"]=1
 [[ -n "$WG0_PEER" ]] && CHOSEN["$WG0_PEER"]=1
 [[ -n "$WG1_PEER" ]] && CHOSEN["$WG1_PEER"]=1
 
 next_free_peer() {
-  local p
-  for p in "${EXISTING_PEERS[@]}"; do
-    if [[ -z "${TAKEN[$p]:-}" && -z "${CHOSEN[$p]:-}" ]]; then
-      echo "$p"; return 0
+  local n peer
+  for n in $(seq 1 "$MAX_PEERS"); do
+    peer="peer${n}"
+    if [[ -z "${TAKEN[$peer]:-}" && -z "${CHOSEN[$peer]:-}" ]]; then
+      ensure_peer_exists "$peer"
+      echo "$peer"
+      return 0
     fi
   done
   return 1
 }
 
 if [[ "$REUSED" != "true" ]]; then
-  if [[ -z "$TF_PEER"  ]]; then TF_PEER="$(next_free_peer)"  || die "No free peers left"; CHOSEN["$TF_PEER"]=1;  fi
-  if [[ -z "$WG0_PEER" ]]; then WG0_PEER="$(next_free_peer)" || die "No free peers left"; CHOSEN["$WG0_PEER"]=1; fi
-  if [[ -z "$WG1_PEER" ]]; then WG1_PEER="$(next_free_peer)" || die "No free peers left"; CHOSEN["$WG1_PEER"]=1; fi
+  if [[ -z "$TF_PEER"  ]]; then TF_PEER="$(next_free_peer)"  || die "No free peers left in peer1..peer${MAX_PEERS}"; CHOSEN["$TF_PEER"]=1;  fi
+  if [[ -z "$WG0_PEER" ]]; then WG0_PEER="$(next_free_peer)" || die "No free peers left in peer1..peer${MAX_PEERS}"; CHOSEN["$WG0_PEER"]=1; fi
+  if [[ -z "$WG1_PEER" ]]; then WG1_PEER="$(next_free_peer)" || die "No free peers left in peer1..peer${MAX_PEERS}"; CHOSEN["$WG1_PEER"]=1; fi
 fi
 
-# sanity: all three distinct and exist
 for p in "$TF_PEER" "$WG0_PEER" "$WG1_PEER"; do
-  printf '%s\n' "${EXISTING_PEERS[@]}" | grep -qx "$p" || die "Peer $p does not exist under $CONFIG_DIR"
+  if [[ -n "${TAKEN[$p]:-}" ]]; then
+    die "Refusing to allocate $p — already assigned in $ASSIGNED_FILE (script may have failed to read labels; check file format/permissions)"
+  fi
+done
+
+# Ensure explicit/reused peers exist before reading their confs
+for p in "$TF_PEER" "$WG0_PEER" "$WG1_PEER"; do
+  ensure_peer_exists "$p"
 done
 [[ "$TF_PEER" != "$WG0_PEER" && "$TF_PEER" != "$WG1_PEER" && "$WG0_PEER" != "$WG1_PEER" ]] \
   || die "Peers must be distinct (TF=$TF_PEER WG0=$WG0_PEER WG1=$WG1_PEER)"
@@ -197,6 +470,10 @@ transform_conf() {
 
 fetch_and_transform() {
   local peer="$1" raw
+  if [[ "$DRY_RUN" == "true" ]] && ! peer_config_exists "$peer"; then
+    echo "[DRY RUN] peer config for $peer not present yet"
+    return 0
+  fi
   raw="$(ssh_cmd "cat '$CONFIG_DIR/$peer/$peer.conf' 2>/dev/null || sudo cat '$CONFIG_DIR/$peer/$peer.conf'" 2>/dev/null || true)"
   [[ -n "$raw" ]] || die "Could not read $CONFIG_DIR/$peer/$peer.conf"
   grep -q '^[[:space:]]*AllowedIPs' <<<"$raw" || die "$peer.conf has no AllowedIPs line"
@@ -207,24 +484,40 @@ log "Fetching and transforming peer configs ..."
 TF_CONF="$(fetch_and_transform "$TF_PEER")"
 WG0_CONF="$(fetch_and_transform "$WG0_PEER")"
 WG1_CONF="$(fetch_and_transform "$WG1_PEER")"
-log "Transformed: stripped DNS, set AllowedIPs=${ALLOWED_IPS} on all three confs."
+if [[ "$DRY_RUN" != "true" ]]; then
+  log "Transformed: stripped DNS, set AllowedIPs=${ALLOWED_IPS} on all three confs."
+fi
 
 if [[ "$DRY_RUN" == "true" ]]; then
-  log "DRY RUN - would append to $ASSIGNED_FILE:"
-  log "    $TF_PEER  ${LABEL}(TF_WG_CONFIG)"
-  log "    $WG0_PEER ${LABEL}(CLUSTER_WIREGUARD_WG0)"
-  log "    $WG1_PEER ${LABEL}(CLUSTER_WIREGUARD_WG1)"
+  log "DRY RUN - would update $ASSIGNED_FILE:"
+  if [[ "$ASSIGNED_FORMAT" == "colon" ]]; then
+    log "    $TF_PEER: $ENV_NAME"
+    log "    $WG0_PEER: $ENV_NAME"
+    log "    $WG1_PEER: $ENV_NAME"
+  else
+    log "    $TF_PEER  ${LABEL}(TF_WG_CONFIG)"
+    log "    $WG0_PEER ${LABEL}(CLUSTER_WIREGUARD_WG0)"
+    log "    $WG1_PEER ${LABEL}(CLUSTER_WIREGUARD_WG1)"
+  fi
   log "DRY RUN - would create env '$ENV_NAME' and set 3 secrets (values not shown)."
-  log "DRY RUN - AllowedIPs in each conf: $(grep -h '^AllowedIPs' <<<"$TF_CONF" | head -1)"
+  if grep -q '^AllowedIPs' <<<"$TF_CONF" 2>/dev/null; then
+    log "DRY RUN - AllowedIPs in each conf: $(grep -h '^AllowedIPs' <<<"$TF_CONF" | head -1)"
+  fi
   exit 0
 fi
 
-# ---- Append to assigned.txt on the jumpserver (skip if reused) -------------
+# ---- Update assigned.txt on the jumpserver (skip if reused) ------------------
 if [[ "$REUSED" != "true" ]]; then
   log "Recording assignment in $ASSIGNED_FILE on jumpserver ..."
-  printf '%s %s(TF_WG_CONFIG)\n%s %s(CLUSTER_WIREGUARD_WG0)\n%s %s(CLUSTER_WIREGUARD_WG1)\n' \
-    "$TF_PEER" "$LABEL" "$WG0_PEER" "$LABEL" "$WG1_PEER" "$LABEL" \
-    | ssh_cmd "cat >> '$ASSIGNED_FILE'"
+  if [[ "$ASSIGNED_FORMAT" == "colon" ]]; then
+    record_peer_assignment "$TF_PEER" "$ENV_NAME"
+    record_peer_assignment "$WG0_PEER" "$ENV_NAME"
+    record_peer_assignment "$WG1_PEER" "$ENV_NAME"
+  else
+    record_peer_assignment "$TF_PEER" "${LABEL}(TF_WG_CONFIG)"
+    record_peer_assignment "$WG0_PEER" "${LABEL}(CLUSTER_WIREGUARD_WG0)"
+    record_peer_assignment "$WG1_PEER" "${LABEL}(CLUSTER_WIREGUARD_WG1)"
+  fi
 fi
 
 # ---- Create the GitHub environment + publish the three secrets -------------

--- a/.github/scripts/wg-onboard.sh
+++ b/.github/scripts/wg-onboard.sh
@@ -116,6 +116,8 @@ done
 [[ -n "$JUMPSERVER_HOST" ]] || die "--host is required"
 [[ -n "$SSH_KEY" ]]         || die "--ssh-key is required"
 [[ -f "$SSH_KEY" ]]         || die "ssh key not found: $SSH_KEY"
+[[ "$ALLOWED_IPS" =~ ^[0-9]+(\.[0-9]+){3}/[0-9]+$ ]] \
+  || die "--allowed-ips must be an IPv4 CIDR (e.g. 172.31.0.0/16), got: $ALLOWED_IPS"
 command -v gh  >/dev/null 2>&1 || die "gh CLI is required"
 command -v ssh >/dev/null 2>&1 || die "ssh is required"
 
@@ -126,6 +128,7 @@ fi
 
 CONFIG_DIR="$WG_DIR/config"
 ASSIGNED_FILE="$WG_DIR/assigned.txt"
+ASSIGN_LOCK_FILE="${ASSIGNED_FILE}.lock"
 LABEL="$ENV_NAME"
 [[ -n "$TICKET" ]] && LABEL="${ENV_NAME}(${TICKET})"
 
@@ -149,21 +152,11 @@ ssh_cmd() {
     "${SSH_USER}@${JUMPSERVER_HOST}" "$@"
 }
 
-# ---- Read current state from the jumpserver --------------------------------
-log "Reading assigned.txt and peer inventory from jumpserver ${JUMPSERVER_HOST} ..."
-ASSIGNED_CONTENT="$(ssh_cmd "cat '$ASSIGNED_FILE' 2>/dev/null" || true)"
-ASSIGNED_CONTENT="${ASSIGNED_CONTENT//$'\r'/}"
+# ---- Preflight: jumpserver connectivity + peer pool sizing -------------------
+log "Checking jumpserver connectivity and peer inventory on ${JUMPSERVER_HOST} ..."
 PEER_LISTING="$(ssh_cmd "ls '$CONFIG_DIR'" 2>/dev/null || true)"
 [[ -n "$PEER_LISTING" ]] || die "Could not list $CONFIG_DIR on jumpserver (check --wg-dir / connectivity)"
 
-if [[ -z "$ASSIGNED_CONTENT" ]]; then
-  log "WARNING: $ASSIGNED_FILE is empty or unreadable over SSH — every peer will look FREE"
-else
-  assigned_lines="$(printf '%s\n' "$ASSIGNED_CONTENT" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')"
-  log "Loaded $ASSIGNED_FILE ($assigned_lines non-empty lines)"
-fi
-
-# Peers that physically exist as client configs
 mapfile -t EXISTING_PEERS < <(printf '%s\n' "$PEER_LISTING" | grep -E '^peer[0-9]+$' | sort -t r -k2 -n)
 
 peer_number() {
@@ -172,14 +165,70 @@ peer_number() {
   echo "${BASH_REMATCH[1]}"
 }
 
-# Normalize "peer1" or "peer1:" from assigned.txt first field.
+highest_config_peer() {
+  local max=0 n peer
+  for peer in "${EXISTING_PEERS[@]}"; do
+    n="$(peer_number "$peer" || true)"
+    [[ -n "$n" && "$n" -gt "$max" ]] && max="$n"
+  done
+  echo "$max"
+}
+
+if [[ -z "$MAX_PEERS" ]]; then
+  max="$(highest_config_peer)"
+  MAX_PEERS=$(( max > 100 ? max : 100 ))
+else
+  [[ "$MAX_PEERS" =~ ^[0-9]+$ && "$MAX_PEERS" -gt 0 ]] || die "--max-peers must be a positive integer"
+  detected_max="$(highest_config_peer)"
+  [[ "$detected_max" -eq 0 || "$MAX_PEERS" -ge "$detected_max" ]] \
+    || die "--max-peers ($MAX_PEERS) is less than highest peer on jumpserver (peer${detected_max})"
+fi
+log "Peer pool: peer1..peer${MAX_PEERS} (gap-fill order, create missing peers on demand)"
+
+CAN_CREATE_PEERS="false"
+if [[ ${#EXISTING_PEERS[@]} -gt 0 ]] \
+  || ssh_cmd "test -f '$CONFIG_DIR/templates/peer.conf' || test -f '$CONFIG_DIR/peer1/peer1.conf'" 2>/dev/null; then
+  CAN_CREATE_PEERS="true"
+else
+  die "No peer directories or templates under $CONFIG_DIR (cannot create missing peers)"
+fi
+
+peer_config_exists() {
+  local peer="$1"
+  ssh_cmd "test -f '$CONFIG_DIR/$peer/$peer.conf'" 2>/dev/null
+}
+
+# ---- Flock-guarded read → select → record on the jumpserver ---------------
+# Runs atomically on the VM before secrets are published (eliminates the race
+# where two workflows read the same free peers and both append assigned.txt).
+atomic_allocate_peers() {
+  ssh_cmd bash -s \
+    "$ASSIGNED_FILE" "$ASSIGN_LOCK_FILE" "$CONFIG_DIR" "$ENV_NAME" "$LABEL" \
+    "$MAX_PEERS" "$TF_PEER" "$WG0_PEER" "$WG1_PEER" "$DRY_RUN" "$CAN_CREATE_PEERS" \
+    <<'REMOTE_ATOMIC_ALLOCATE'
+set -euo pipefail
+
+ASSIGNED_FILE="$1"
+LOCK_FILE="$2"
+CONFIG_DIR="$3"
+ENV_NAME="$4"
+LABEL="$5"
+MAX_PEERS="$6"
+FORCE_TF="$7"
+FORCE_WG0="$8"
+FORCE_WG1="$9"
+DRY_RUN="${10}"
+CAN_CREATE="${11}"
+
+PARSED_PEER=""
+PARSED_LABEL=""
+
 normalize_peer_token() {
   local token="${1//$'\r'/}"
   token="${token%%:*}"
-  echo "$token"
+  printf '%s' "$token"
 }
 
-# Parse one assigned.txt line -> PARSED_PEER / PARSED_LABEL (label empty = free).
 parse_assigned_line() {
   local line="${1//$'\r'/}"
   local peer rest
@@ -200,157 +249,75 @@ parse_assigned_line() {
   return 0
 }
 
-# Blank label or explicit ": available" means the peer is free.
 peer_label_is_taken() {
   local label="${1//[[:space:]]/}"
   [[ -n "$label" && "${label,,}" != "available" ]]
 }
 
-assigned_line_exists() {
-  local peer="$1"
-  grep -qE "^${peer}([[:space:]]|:)" <<<"$ASSIGNED_CONTENT"
-}
-
-highest_peer_number() {
-  local max=0 n peer
-  for peer in "${EXISTING_PEERS[@]}"; do
-    n="$(peer_number "$peer" || true)"
-    [[ -n "$n" && "$n" -gt "$max" ]] && max="$n"
-  done
-  while IFS= read -r line; do
-    parse_assigned_line "$line" || continue
-    n="$(peer_number "$PARSED_PEER" || true)"
-    [[ -n "$n" && "$n" -gt "$max" ]] && max="$n"
-  done <<<"$ASSIGNED_CONTENT"
-  echo "$max"
-}
-
-if [[ -z "$MAX_PEERS" ]]; then
-  detected_max="$(highest_peer_number)"
-  MAX_PEERS=$(( detected_max > 100 ? detected_max : 100 ))
-else
-  [[ "$MAX_PEERS" =~ ^[0-9]+$ && "$MAX_PEERS" -gt 0 ]] || die "--max-peers must be a positive integer"
-fi
-log "Peer pool: peer1..peer${MAX_PEERS} (gap-fill order, create missing peers on demand)"
-
-CAN_CREATE_PEERS="false"
-if [[ ${#EXISTING_PEERS[@]} -gt 0 ]] \
-  || ssh_cmd "test -f '$CONFIG_DIR/templates/peer.conf' || test -f '$CONFIG_DIR/peer1/peer1.conf'" 2>/dev/null; then
-  CAN_CREATE_PEERS="true"
-else
-  die "No peer directories or templates under $CONFIG_DIR (cannot create missing peers)"
-fi
-
-# Detect assigned.txt layout (colon vs per-secret MOSIP format).
-ASSIGNED_FORMAT="mosip"
-if grep -qE '^peer[0-9]+[[:space:]]*:' <<<"$ASSIGNED_CONTENT"; then
-  ASSIGNED_FORMAT="colon"
-  log "Detected assigned.txt colon format (peerN: username)"
-fi
-
-# Peers already taken: any peerN line with a non-empty label/username.
-declare -A TAKEN=()
-while IFS= read -r line; do
-  parse_assigned_line "$line" || continue
-  peer_label_is_taken "$PARSED_LABEL" && TAKEN["$PARSED_PEER"]=1
-done <<<"$ASSIGNED_CONTENT"
-
-if [[ ${#TAKEN[@]} -gt 0 ]]; then
-  taken_sample="$(printf '%s\n' "${!TAKEN[@]}" | sort -t r -k2 -n | head -5 | paste -sd, -)"
-  log "Marked ${#TAKEN[@]} peers as taken in $ASSIGNED_FILE (e.g. ${taken_sample})"
-else
-  log "No taken peers parsed from $ASSIGNED_FILE — will start from peer1 unless gaps apply"
-fi
-
-peer_config_exists() {
-  local peer="$1"
-  ssh_cmd "test -f '$CONFIG_DIR/$peer/$peer.conf'" 2>/dev/null
-}
-
-ensure_assigned_entry() {
-  local peer="$1"
-  assigned_line_exists "$peer" && return 0
-  if [[ "$DRY_RUN" == "true" ]]; then
-    if [[ "$ASSIGNED_FORMAT" == "colon" ]]; then
-      log "DRY RUN - would append free slot to $ASSIGNED_FILE: ${peer}:"
+record_assignment() {
+  local peer="$1" assignment="$2" format="$3" file="$4"
+  if [[ "$format" == "colon" ]]; then
+    local line="${peer}: ${assignment}"
+    if grep -qE "^${peer}:" "$file"; then
+      sed -i "s|^${peer}:.*|${line}|" "$file"
+    elif grep -qE "^${peer}([[:space:]]|$)" "$file"; then
+      sed -i "s|^${peer}.*|${line}|" "$file"
     else
-      log "DRY RUN - would append free slot to $ASSIGNED_FILE: ${peer}"
+      printf '%s\n' "$line" >> "$file"
     fi
-    return 0
-  fi
-  log "Adding free slot ${peer} to $ASSIGNED_FILE ..."
-  if [[ "$ASSIGNED_FORMAT" == "colon" ]]; then
-    printf '%s:\n' "$peer" | ssh_cmd "cat >> '$ASSIGNED_FILE'"
-    ASSIGNED_CONTENT+=$'\n'"${peer}:"
   else
-    printf '%s \n' "$peer" | ssh_cmd "cat >> '$ASSIGNED_FILE'"
-    ASSIGNED_CONTENT+=$'\n'"${peer} "
+    local line="${peer} ${assignment}"
+    if grep -qE "^${peer}([[:space:]]|$)" "$file"; then
+      sed -i "s|^${peer}.*|${line}|" "$file"
+    else
+      printf '%s\n' "$line" >> "$file"
+    fi
   fi
 }
 
-ensure_peer_exists() {
-  local peer="$1"
-  peer_config_exists "$peer" && return 0
-  [[ "$CAN_CREATE_PEERS" == "true" ]] || die "Peer $peer is missing under $CONFIG_DIR and cannot be created"
-  local peer_num
-  peer_num="$(peer_number "$peer")" || die "Invalid peer id: $peer"
+ensure_peer_conf() {
+  local peer_num="$1"
+  local PEER_ID="peer${peer_num}"
+  [[ -f "$CONFIG_DIR/$PEER_ID/$PEER_ID.conf" ]] && return 0
+  [[ "$CAN_CREATE" == "true" ]] || { echo "ERROR: peer $PEER_ID missing and cannot be created" >&2; return 1; }
+  [[ "$DRY_RUN" == "true" ]] && return 0
 
-  if [[ "$DRY_RUN" == "true" ]]; then
-    log "DRY RUN - would create missing peer $peer on jumpserver"
-    ensure_assigned_entry "$peer"
-    return 0
-  fi
+  mapfile -t REF_DIRS < <(ls -d "$CONFIG_DIR"/peer[0-9]* 2>/dev/null | sort -t r -k2 -n)
+  [[ ${#REF_DIRS[@]} -gt 0 ]] || return 1
+  local REF_CONF="${REF_DIRS[0]}/$(basename "${REF_DIRS[0]}").conf"
+  [[ -f "$REF_CONF" ]] || return 1
 
-  log "Creating missing peer $peer on jumpserver ..."
-  ssh_cmd "bash -s" "$peer_num" "$CONFIG_DIR" <<'REMOTE_CREATE_PEER'
-set -euo pipefail
-PEER_NUM="$1"
-CONFIG_DIR="$2"
-PEER_ID="peer${PEER_NUM}"
+  local INTERFACE ENDPOINT SERVER_PUBKEY PEERDNS C CLIENT_IP PRIV PSK PUB WG_CONF
+  INTERFACE="$(grep -m1 '^Address' "$REF_CONF" | awk '{print $NF}' | awk -F. '{print $1"."$2"."$3}')"
+  ENDPOINT="$(grep -m1 '^Endpoint' "$REF_CONF" | awk '{print $NF}')"
+  SERVER_PUBKEY="$(grep -m1 '^PublicKey' "$REF_CONF" | awk '{print $NF}')"
+  PEERDNS="$(grep -m1 '^DNS' "$REF_CONF" | awk '{print $NF}')"
+  [[ -n "$INTERFACE" && -n "$ENDPOINT" && -n "$SERVER_PUBKEY" ]] || return 1
+  [[ -n "$PEERDNS" ]] || PEERDNS="${INTERFACE}.1"
 
-if [[ -f "$CONFIG_DIR/$PEER_ID/$PEER_ID.conf" ]]; then
-  exit 0
-fi
+  C="$(docker ps --format '{{.Names}}' | grep -iE 'wireguard|wg' | head -1)"
+  [[ -n "$C" ]] || { echo "ERROR: WireGuard docker container not running" >&2; return 1; }
 
-mapfile -t REF_DIRS < <(ls -d "$CONFIG_DIR"/peer[0-9]* 2>/dev/null | sort -t r -k2 -n)
-[[ ${#REF_DIRS[@]} -gt 0 ]] || { echo "No reference peer under $CONFIG_DIR" >&2; exit 1; }
-REF_DIR="${REF_DIRS[0]}"
-REF_ID="$(basename "$REF_DIR")"
-REF_CONF="$REF_DIR/$REF_ID.conf"
-[[ -f "$REF_CONF" ]] || { echo "Missing reference conf: $REF_CONF" >&2; exit 1; }
+  mkdir -p "$CONFIG_DIR/$PEER_ID"
+  umask 077
+  docker exec "$C" wg genkey | tee "$CONFIG_DIR/$PEER_ID/privatekey-$PEER_ID" \
+    | docker exec -i "$C" wg pubkey > "$CONFIG_DIR/$PEER_ID/publickey-$PEER_ID"
+  docker exec "$C" wg genpsk > "$CONFIG_DIR/$PEER_ID/presharedkey-$PEER_ID"
 
-INTERFACE="$(grep -m1 '^Address' "$REF_CONF" | awk '{print $NF}' | awk -F. '{print $1"."$2"."$3}')"
-ENDPOINT="$(grep -m1 '^Endpoint' "$REF_CONF" | awk '{print $NF}')"
-SERVER_PUBKEY="$(grep -m1 '^PublicKey' "$REF_CONF" | awk '{print $NF}')"
-PEERDNS="$(grep -m1 '^DNS' "$REF_CONF" | awk '{print $NF}')"
-[[ -n "$INTERFACE" && -n "$ENDPOINT" && -n "$SERVER_PUBKEY" ]] \
-  || { echo "Could not read reference WireGuard settings from $REF_CONF" >&2; exit 1; }
-[[ -n "$PEERDNS" ]] || PEERDNS="${INTERFACE}.1"
+  CLIENT_IP=""
+  for idx in $(seq 2 254); do
+    if ! grep -qR "${INTERFACE}.${idx}" "$CONFIG_DIR"/peer*/*.conf 2>/dev/null; then
+      CLIENT_IP="${INTERFACE}.${idx}"
+      break
+    fi
+  done
+  [[ -n "$CLIENT_IP" ]] || return 1
 
-C="$(docker ps --format '{{.Names}}' | grep -iE 'wireguard|wg' | head -1 || true)"
-[[ -n "$C" ]] || { echo "WireGuard docker container not found" >&2; exit 1; }
+  PRIV="$(cat "$CONFIG_DIR/$PEER_ID/privatekey-$PEER_ID")"
+  PSK="$(cat "$CONFIG_DIR/$PEER_ID/presharedkey-$PEER_ID")"
+  PUB="$(cat "$CONFIG_DIR/$PEER_ID/publickey-$PEER_ID")"
 
-mkdir -p "$CONFIG_DIR/$PEER_ID"
-umask 077
-docker exec "$C" wg genkey | tee "$CONFIG_DIR/$PEER_ID/privatekey-$PEER_ID" \
-  | docker exec -i "$C" wg pubkey > "$CONFIG_DIR/$PEER_ID/publickey-$PEER_ID"
-docker exec "$C" wg genpsk > "$CONFIG_DIR/$PEER_ID/presharedkey-$PEER_ID"
-
-CLIENT_IP=""
-for idx in $(seq 2 254); do
-  PROPOSED="${INTERFACE}.${idx}"
-  if ! grep -qR "${PROPOSED}" "$CONFIG_DIR"/peer*/*.conf 2>/dev/null; then
-    CLIENT_IP="$PROPOSED"
-    break
-  fi
-done
-[[ -n "$CLIENT_IP" ]] || { echo "No free client IP in ${INTERFACE}.0/24" >&2; exit 1; }
-
-PRIV="$(cat "$CONFIG_DIR/$PEER_ID/privatekey-$PEER_ID")"
-PSK="$(cat "$CONFIG_DIR/$PEER_ID/presharedkey-$PEER_ID")"
-PUB="$(cat "$CONFIG_DIR/$PEER_ID/publickey-$PEER_ID")"
-
-cat > "$CONFIG_DIR/$PEER_ID/$PEER_ID.conf" <<EOF
+  cat > "$CONFIG_DIR/$PEER_ID/$PEER_ID.conf" <<EOF
 [Interface]
 Address = ${CLIENT_IP}
 PrivateKey = ${PRIV}
@@ -364,13 +331,13 @@ Endpoint = ${ENDPOINT}
 AllowedIPs = 0.0.0.0/0, ::/0
 EOF
 
-if [[ -f "$CONFIG_DIR/wg_confs/wg0.conf" ]]; then
-  WG_CONF="$CONFIG_DIR/wg_confs/wg0.conf"
-else
-  WG_CONF="$CONFIG_DIR/wg0.conf"
-fi
+  if [[ -f "$CONFIG_DIR/wg_confs/wg0.conf" ]]; then
+    WG_CONF="$CONFIG_DIR/wg_confs/wg0.conf"
+  else
+    WG_CONF="$CONFIG_DIR/wg0.conf"
+  fi
 
-cat >> "$WG_CONF" <<EOF
+  cat >> "$WG_CONF" <<EOF
 
 [Peer]
 # ${PEER_ID}
@@ -380,125 +347,158 @@ AllowedIPs = ${CLIENT_IP}/32
 
 EOF
 
-docker exec "$C" wg set wg0 peer "$PUB" preshared-key "$PSK" allowed-ips "${CLIENT_IP}/32" \
-  || docker restart "$C" >/dev/null
-REMOTE_CREATE_PEER
-
-  ensure_assigned_entry "$peer"
+  docker exec "$C" wg set wg0 peer "$PUB" preshared-key "$PSK" allowed-ips "${CLIENT_IP}/32" \
+    || docker restart "$C" >/dev/null
 }
 
-record_peer_assignment() {
-  local peer="$1"
-  local assignment="$2"
-  ssh_cmd "bash -s" "$peer" "$assignment" "$ASSIGNED_FILE" "$ASSIGNED_FORMAT" <<'REMOTE_RECORD_ASSIGNMENT'
-set -euo pipefail
-peer="$1"
-assignment="$2"
-file="$3"
-format="$4"
-if [[ "$format" == "colon" ]]; then
-  line="${peer}: ${assignment}"
-  if grep -qE "^${peer}:" "$file"; then
-    sed -i "s|^${peer}:.*|${line}|" "$file"
-  elif grep -qE "^${peer}([[:space:]]|$)" "$file"; then
-    sed -i "s|^${peer}.*|${line}|" "$file"
-  else
-    printf '%s\n' "$line" >> "$file"
+run_allocation() {
+  local assigned_content line n peer
+  local -A TAKEN=() CHOSEN=()
+  local tf="" wg0="" wg1="" reused="false" format="mosip"
+
+  assigned_content="$(cat "$ASSIGNED_FILE" 2>/dev/null || true)"
+  assigned_content="${assigned_content//$'\r'/}"
+
+  if grep -qE '^peer[0-9]+[[:space:]]*:' <<<"$assigned_content"; then
+    format="colon"
   fi
-else
-  line="${peer} ${assignment}"
-  if grep -qE "^${peer}([[:space:]]|$)" "$file"; then
-    sed -i "s|^${peer}.*|${line}|" "$file"
-  else
-    printf '%s\n' "$line" >> "$file"
-  fi
-fi
-REMOTE_RECORD_ASSIGNMENT
-}
 
-# ---- Reuse existing allocation for this env, if present (idempotent) -------
-find_assigned_peer() {
-  local secret="$1"
-  awk -v env="$ENV_NAME" -v secret="$secret" '
-    $1 ~ /^peer[0-9]+:?$/ {
-      peer=$1
-      sub(/:$/, "", peer)
-      desc=$0
-      sub(/^[[:space:]]*peer[0-9]+[[:space:]]*:?[[:space:]]*/, "", desc)
-      suffix="(" secret ")"
-      if (length(desc) < length(suffix)) next
-      if (substr(desc, length(desc) - length(suffix) + 1) != suffix) next
-      label=substr(desc, 1, length(desc) - length(suffix))
-      if (label == env || index(label, env "(") == 1) { print peer; exit }
-    }' <<<"$ASSIGNED_CONTENT"
-}
-
-find_colon_env_peers() {
-  local line
   while IFS= read -r line; do
     parse_assigned_line "$line" || continue
-    [[ "$PARSED_LABEL" == "$ENV_NAME" ]] && echo "$PARSED_PEER"
-  done <<<"$ASSIGNED_CONTENT"
-}
+    peer_label_is_taken "$PARSED_LABEL" && TAKEN["$PARSED_PEER"]=1
+  done <<<"$assigned_content"
 
-REUSED="false"
-if [[ -z "$TF_PEER" && -z "$WG0_PEER" && -z "$WG1_PEER" ]]; then
-  if [[ "$ASSIGNED_FORMAT" == "colon" ]]; then
-    mapfile -t COLON_REUSED < <(find_colon_env_peers | sort -t r -k2 -n)
-    if [[ ${#COLON_REUSED[@]} -ge 3 ]]; then
-      TF_PEER="${COLON_REUSED[0]}"; WG0_PEER="${COLON_REUSED[1]}"; WG1_PEER="${COLON_REUSED[2]}"
-      REUSED="true"
-      log "Reusing existing colon-format allocation for $ENV_NAME: TF=$TF_PEER WG0=$WG0_PEER WG1=$WG1_PEER"
-    fi
-  else
-    rtf="$(find_assigned_peer TF_WG_CONFIG)"
-    rwg0="$(find_assigned_peer CLUSTER_WIREGUARD_WG0)"
-    rwg1="$(find_assigned_peer CLUSTER_WIREGUARD_WG1)"
-    if [[ -n "$rtf" && -n "$rwg0" && -n "$rwg1" ]]; then
-      TF_PEER="$rtf"; WG0_PEER="$rwg0"; WG1_PEER="$rwg1"; REUSED="true"
-      log "Reusing existing allocation for $ENV_NAME: TF=$TF_PEER WG0=$WG0_PEER WG1=$WG1_PEER"
+  if [[ -z "$FORCE_TF" && -z "$FORCE_WG0" && -z "$FORCE_WG1" ]]; then
+    if [[ "$format" == "colon" ]]; then
+      mapfile -t colon_reused < <(while IFS= read -r line; do
+        parse_assigned_line "$line" || continue
+        [[ "$PARSED_LABEL" == "$ENV_NAME" ]] && echo "$PARSED_PEER"
+      done <<<"$assigned_content" | sort -t r -k2 -n)
+      if [[ ${#colon_reused[@]} -ge 3 ]]; then
+        tf="${colon_reused[0]}"; wg0="${colon_reused[1]}"; wg1="${colon_reused[2]}"
+        reused="true"
+      fi
+    else
+      tf="$(awk -v env="$ENV_NAME" -v secret="TF_WG_CONFIG" '
+        $1 ~ /^peer[0-9]+:?$/ {
+          peer=$1; sub(/:$/, "", peer)
+          desc=$0; sub(/^[[:space:]]*peer[0-9]+[[:space:]]*:?[[:space:]]*/, "", desc)
+          suffix="(" secret ")"
+          if (length(desc) < length(suffix)) next
+          if (substr(desc, length(desc) - length(suffix) + 1) != suffix) next
+          label=substr(desc, 1, length(desc) - length(suffix))
+          if (label == env || index(label, env "(") == 1) { print peer; exit }
+        }' <<<"$assigned_content")"
+      wg0="$(awk -v env="$ENV_NAME" -v secret="CLUSTER_WIREGUARD_WG0" '
+        $1 ~ /^peer[0-9]+:?$/ {
+          peer=$1; sub(/:$/, "", peer)
+          desc=$0; sub(/^[[:space:]]*peer[0-9]+[[:space:]]*:?[[:space:]]*/, "", desc)
+          suffix="(" secret ")"
+          if (length(desc) < length(suffix)) next
+          if (substr(desc, length(desc) - length(suffix) + 1) != suffix) next
+          label=substr(desc, 1, length(desc) - length(suffix))
+          if (label == env || index(label, env "(") == 1) { print peer; exit }
+        }' <<<"$assigned_content")"
+      wg1="$(awk -v env="$ENV_NAME" -v secret="CLUSTER_WIREGUARD_WG1" '
+        $1 ~ /^peer[0-9]+:?$/ {
+          peer=$1; sub(/:$/, "", peer)
+          desc=$0; sub(/^[[:space:]]*peer[0-9]+[[:space:]]*:?[[:space:]]*/, "", desc)
+          suffix="(" secret ")"
+          if (length(desc) < length(suffix)) next
+          if (substr(desc, length(desc) - length(suffix) + 1) != suffix) next
+          label=substr(desc, 1, length(desc) - length(suffix))
+          if (label == env || index(label, env "(") == 1) { print peer; exit }
+        }' <<<"$assigned_content")"
+      if [[ -n "$tf" && -n "$wg0" && -n "$wg1" ]]; then
+        reused="true"
+      fi
     fi
   fi
-fi
 
-# ---- Allocate next free peers for any not explicitly set / reused ----------
-# Walk peer1..peerMAX in numeric order so gaps (e.g. peer66) are reused first.
-declare -A CHOSEN=()
-[[ -n "$TF_PEER"  ]] && CHOSEN["$TF_PEER"]=1
-[[ -n "$WG0_PEER" ]] && CHOSEN["$WG0_PEER"]=1
-[[ -n "$WG1_PEER" ]] && CHOSEN["$WG1_PEER"]=1
+  [[ -n "$FORCE_TF"  ]] && tf="$FORCE_TF"  && CHOSEN["$tf"]=1
+  [[ -n "$FORCE_WG0" ]] && wg0="$FORCE_WG0" && CHOSEN["$wg0"]=1
+  [[ -n "$FORCE_WG1" ]] && wg1="$FORCE_WG1" && CHOSEN["$wg1"]=1
 
-next_free_peer() {
-  local n peer
-  for n in $(seq 1 "$MAX_PEERS"); do
-    peer="peer${n}"
-    if [[ -z "${TAKEN[$peer]:-}" && -z "${CHOSEN[$peer]:-}" ]]; then
-      ensure_peer_exists "$peer"
-      echo "$peer"
-      return 0
-    fi
+  next_free() {
+    local i pnum
+    for ((i = 1; i <= MAX_PEERS; i++)); do
+      peer="peer${i}"
+      if [[ -z "${TAKEN[$peer]:-}" && -z "${CHOSEN[$peer]:-}" ]]; then
+        ensure_peer_conf "$i" || return 1
+        echo "$peer"
+        return 0
+      fi
+    done
+    return 1
+  }
+
+  if [[ "$reused" != "true" ]]; then
+    if [[ -z "$tf"  ]]; then tf="$(next_free)"  || { echo "ERROR: no free peers in peer1..peer${MAX_PEERS}" >&2; return 1; }; CHOSEN["$tf"]=1;  fi
+    if [[ -z "$wg0" ]]; then wg0="$(next_free)" || { echo "ERROR: no free peers in peer1..peer${MAX_PEERS}" >&2; return 1; }; CHOSEN["$wg0"]=1; fi
+    if [[ -z "$wg1" ]]; then wg1="$(next_free)" || { echo "ERROR: no free peers in peer1..peer${MAX_PEERS}" >&2; return 1; }; CHOSEN["$wg1"]=1; fi
+  fi
+
+  for peer in "$tf" "$wg0" "$wg1"; do
+    [[ "$reused" != "true" && -n "${TAKEN[$peer]:-}" ]] \
+      && { echo "ERROR: $peer already assigned in $ASSIGNED_FILE" >&2; return 1; }
+    [[ "$peer" =~ ^peer[0-9]+$ ]] || { echo "ERROR: invalid peer id $peer" >&2; return 1; }
+    n="${peer#peer}"
+    ensure_peer_conf "$n" || true
   done
-  return 1
+
+  [[ "$tf" != "$wg0" && "$tf" != "$wg1" && "$wg0" != "$wg1" ]] \
+    || { echo "ERROR: peers must be distinct (tf=$tf wg0=$wg0 wg1=$wg1)" >&2; return 1; }
+
+  if [[ "$reused" != "true" && "$DRY_RUN" != "true" ]]; then
+    if [[ "$format" == "colon" ]]; then
+      record_assignment "$tf"  "$ENV_NAME" "$format" "$ASSIGNED_FILE"
+      record_assignment "$wg0" "$ENV_NAME" "$format" "$ASSIGNED_FILE"
+      record_assignment "$wg1" "$ENV_NAME" "$format" "$ASSIGNED_FILE"
+    else
+      record_assignment "$tf"  "${LABEL}(TF_WG_CONFIG)" "$format" "$ASSIGNED_FILE"
+      record_assignment "$wg0" "${LABEL}(CLUSTER_WIREGUARD_WG0)" "$format" "$ASSIGNED_FILE"
+      record_assignment "$wg1" "${LABEL}(CLUSTER_WIREGUARD_WG1)" "$format" "$ASSIGNED_FILE"
+    fi
+  fi
+
+  printf 'ASSIGNED_FORMAT=%s\nREUSED=%s\nTF_PEER=%s\nWG0_PEER=%s\nWG1_PEER=%s\n' \
+    "$format" "$reused" "$tf" "$wg0" "$wg1"
 }
 
-if [[ "$REUSED" != "true" ]]; then
-  if [[ -z "$TF_PEER"  ]]; then TF_PEER="$(next_free_peer)"  || die "No free peers left in peer1..peer${MAX_PEERS}"; CHOSEN["$TF_PEER"]=1;  fi
-  if [[ -z "$WG0_PEER" ]]; then WG0_PEER="$(next_free_peer)" || die "No free peers left in peer1..peer${MAX_PEERS}"; CHOSEN["$WG0_PEER"]=1; fi
-  if [[ -z "$WG1_PEER" ]]; then WG1_PEER="$(next_free_peer)" || die "No free peers left in peer1..peer${MAX_PEERS}"; CHOSEN["$WG1_PEER"]=1; fi
+exec 9>"$LOCK_FILE"
+if ! flock -w 120 9; then
+  echo "ERROR: timed out waiting for allocation lock ($LOCK_FILE)" >&2
+  exit 1
 fi
+run_allocation
+REMOTE_ATOMIC_ALLOCATE
+}
 
-for p in "$TF_PEER" "$WG0_PEER" "$WG1_PEER"; do
-  if [[ "$REUSED" != "true" && -n "${TAKEN[$p]:-}" ]]; then
-    die "Refusing to allocate $p — already assigned in $ASSIGNED_FILE (script may have failed to read labels; check file format/permissions)"
-  fi
-done
+log "Allocating peers on jumpserver under flock ($ASSIGN_LOCK_FILE) ..."
+ALLOC_RESULT="$(atomic_allocate_peers)" || die "Peer allocation failed on jumpserver"
+ASSIGNED_FORMAT="mosip"
+REUSED="false"
+TF_PEER=""
+WG0_PEER=""
+WG1_PEER=""
+while IFS= read -r line; do
+  [[ "$line" == *=* ]] || continue
+  case "${line%%=*}" in
+    ASSIGNED_FORMAT) ASSIGNED_FORMAT="${line#*=}" ;;
+    REUSED)          REUSED="${line#*=}" ;;
+    TF_PEER)         TF_PEER="${line#*=}" ;;
+    WG0_PEER)        WG0_PEER="${line#*=}" ;;
+    WG1_PEER)        WG1_PEER="${line#*=}" ;;
+  esac
+done <<<"$ALLOC_RESULT"
+[[ -n "$TF_PEER" && -n "$WG0_PEER" && -n "$WG1_PEER" ]] \
+  || die "Allocation returned incomplete peer set"
 
-# Ensure explicit/reused peers exist before reading their confs
-for p in "$TF_PEER" "$WG0_PEER" "$WG1_PEER"; do
-  ensure_peer_exists "$p"
-done
-[[ "$TF_PEER" != "$WG0_PEER" && "$TF_PEER" != "$WG1_PEER" && "$WG0_PEER" != "$WG1_PEER" ]] \
-  || die "Peers must be distinct (TF=$TF_PEER WG0=$WG0_PEER WG1=$WG1_PEER)"
+if [[ "$REUSED" == "true" ]]; then
+  log "Reusing existing allocation for $ENV_NAME: TF=$TF_PEER WG0=$WG0_PEER WG1=$WG1_PEER"
+elif [[ "$ASSIGNED_FORMAT" == "colon" ]]; then
+  log "Detected assigned.txt colon format (peerN: username)"
+fi
 
 log "Allocation -> TF_WG_CONFIG=$TF_PEER | CLUSTER_WIREGUARD_WG0=$WG0_PEER | CLUSTER_WIREGUARD_WG1=$WG1_PEER"
 
@@ -547,20 +547,6 @@ if [[ "$DRY_RUN" == "true" ]]; then
   exit 0
 fi
 
-# ---- Update assigned.txt on the jumpserver (skip if reused) ------------------
-if [[ "$REUSED" != "true" ]]; then
-  log "Recording assignment in $ASSIGNED_FILE on jumpserver ..."
-  if [[ "$ASSIGNED_FORMAT" == "colon" ]]; then
-    record_peer_assignment "$TF_PEER" "$ENV_NAME"
-    record_peer_assignment "$WG0_PEER" "$ENV_NAME"
-    record_peer_assignment "$WG1_PEER" "$ENV_NAME"
-  else
-    record_peer_assignment "$TF_PEER" "${LABEL}(TF_WG_CONFIG)"
-    record_peer_assignment "$WG0_PEER" "${LABEL}(CLUSTER_WIREGUARD_WG0)"
-    record_peer_assignment "$WG1_PEER" "${LABEL}(CLUSTER_WIREGUARD_WG1)"
-  fi
-fi
-
 # ---- Create the GitHub environment + publish the three secrets -------------
 log "Ensuring GitHub environment '$ENV_NAME' exists ..."
 ENV_NAME_ENC="$(urlencode "$ENV_NAME")"
@@ -568,9 +554,11 @@ gh api --method PUT -H "Accept: application/vnd.github+json" \
   "repos/${REPO}/environments/${ENV_NAME_ENC}" >/dev/null
 
 log "Publishing environment secrets ..."
-printf '%s' "$TF_CONF"  | gh secret set TF_WG_CONFIG          --env "$ENV_NAME" --repo "$REPO" --body -
-printf '%s' "$WG0_CONF" | gh secret set CLUSTER_WIREGUARD_WG0 --env "$ENV_NAME" --repo "$REPO" --body -
-printf '%s' "$WG1_CONF" | gh secret set CLUSTER_WIREGUARD_WG1 --env "$ENV_NAME" --repo "$REPO" --body -
+PEER_CONFS=("$TF_CONF" "$WG0_CONF" "$WG1_CONF")
+for i in "${!SECRET_NAMES[@]}"; do
+  printf '%s' "${PEER_CONFS[$i]}" \
+    | gh secret set "${SECRET_NAMES[$i]}" --env "$ENV_NAME" --repo "$REPO" --body -
+done
 
 # ---- Mirror allocation into the repo tracker (for visibility/PR history) ----
 if [[ ! -f "$ALLOCATION_FILE" ]]; then

--- a/.github/scripts/wg-onboard.sh
+++ b/.github/scripts/wg-onboard.sh
@@ -75,19 +75,37 @@ log()  { echo "[wg-onboard] $*" >&2; }
 err()  { echo "[wg-onboard][ERROR] $*" >&2; }
 die()  { err "$*"; exit 1; }
 
+require_arg() {
+  local flag="$1"
+  [[ $# -ge 2 && -n "${2:-}" && "$2" != --* ]] || die "$flag requires a value"
+}
+
+urlencode() {
+  local input="$1" output="" i c
+  local LC_ALL=C
+  for ((i = 0; i < ${#input}; i++)); do
+    c="${input:i:1}"
+    case "$c" in
+      [a-zA-Z0-9.~_-]) output+="$c" ;;
+      *) printf -v output '%s%%%02X' "$output" "'$c" ;;
+    esac
+  done
+  printf '%s' "$output"
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --env)         ENV_NAME="$2"; shift 2 ;;
-    --host)        JUMPSERVER_HOST="$2"; shift 2 ;;
-    --ssh-key)     SSH_KEY="$2"; shift 2 ;;
-    --repo)        REPO="$2"; shift 2 ;;
-    --ticket)      TICKET="$2"; shift 2 ;;
-    --wg-dir)      WG_DIR="$2"; shift 2 ;;
-    --allowed-ips) ALLOWED_IPS="$2"; shift 2 ;;
-    --tf-peer)     TF_PEER="$2"; shift 2 ;;
-    --wg0-peer)    WG0_PEER="$2"; shift 2 ;;
-    --wg1-peer)    WG1_PEER="$2"; shift 2 ;;
-    --max-peers)   MAX_PEERS="$2"; shift 2 ;;
+    --env)         require_arg --env "$2";         ENV_NAME="$2"; shift 2 ;;
+    --host)        require_arg --host "$2";        JUMPSERVER_HOST="$2"; shift 2 ;;
+    --ssh-key)     require_arg --ssh-key "$2";     SSH_KEY="$2"; shift 2 ;;
+    --repo)        require_arg --repo "$2";        REPO="$2"; shift 2 ;;
+    --ticket)      require_arg --ticket "$2";      TICKET="$2"; shift 2 ;;
+    --wg-dir)      require_arg --wg-dir "$2";      WG_DIR="$2"; shift 2 ;;
+    --allowed-ips) require_arg --allowed-ips "$2"; ALLOWED_IPS="$2"; shift 2 ;;
+    --tf-peer)     require_arg --tf-peer "$2";     TF_PEER="$2"; shift 2 ;;
+    --wg0-peer)    require_arg --wg0-peer "$2";    WG0_PEER="$2"; shift 2 ;;
+    --wg1-peer)    require_arg --wg1-peer "$2";    WG1_PEER="$2"; shift 2 ;;
+    --max-peers)   require_arg --max-peers "$2";   MAX_PEERS="$2"; shift 2 ;;
     --dry-run)     DRY_RUN="true"; shift ;;
     -h|--help)     usage; exit 0 ;;
     *)             die "Unknown argument: $1 (use --help)" ;;
@@ -115,8 +133,19 @@ log "Target repo: $REPO"
 log "Target environment: $ENV_NAME (label: $LABEL)"
 log "WireGuard dir: $WG_DIR | AllowedIPs: $ALLOWED_IPS"
 
+if [[ -n "${SSH_KNOWN_HOSTS:-}" ]]; then
+  [[ -f "$SSH_KNOWN_HOSTS" ]] || die "SSH_KNOWN_HOSTS file not found: $SSH_KNOWN_HOSTS"
+else
+  SSH_KNOWN_HOSTS="$(mktemp /tmp/wg_onboard_known_hosts.XXXXXX)"
+  trap 'rm -f "$SSH_KNOWN_HOSTS"' EXIT
+fi
+
 ssh_cmd() {
-  ssh -i "$SSH_KEY" -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
+  ssh -i "$SSH_KEY" \
+    -o BatchMode=yes \
+    -o StrictHostKeyChecking=accept-new \
+    -o UserKnownHostsFile="$SSH_KNOWN_HOSTS" \
+    -o ConnectTimeout=15 \
     "${SSH_USER}@${JUMPSERVER_HOST}" "$@"
 }
 
@@ -159,15 +188,22 @@ parse_assigned_line() {
   [[ -z "${line//[[:space:]]/}" ]] && return 1
   peer="$(normalize_peer_token "$(awk '{print $1}' <<<"$line")")"
   [[ "$peer" =~ ^peer[0-9]+$ ]] || return 1
-  if [[ "$line" =~ ^peer[0-9]+:[[:space:]]*(.*)$ ]]; then
+  if [[ "$line" =~ ^peer[0-9]+[[:space:]]*:[[:space:]]*(.*)$ ]]; then
     rest="${BASH_REMATCH[1]}"
   else
     rest="$(awk '{$1=""; sub(/^ +/,""); print}' <<<"$line")"
   fi
   rest="${rest//$'\r'/}"
+  rest="$(awk '{$1=$1; print}' <<<"$rest")"
   PARSED_PEER="$peer"
   PARSED_LABEL="$rest"
   return 0
+}
+
+# Blank label or explicit ": available" means the peer is free.
+peer_label_is_taken() {
+  local label="${1//[[:space:]]/}"
+  [[ -n "$label" && "${label,,}" != "available" ]]
 }
 
 assigned_line_exists() {
@@ -207,7 +243,7 @@ fi
 
 # Detect assigned.txt layout (colon vs per-secret MOSIP format).
 ASSIGNED_FORMAT="mosip"
-if grep -qE '^peer[0-9]+:' <<<"$ASSIGNED_CONTENT"; then
+if grep -qE '^peer[0-9]+[[:space:]]*:' <<<"$ASSIGNED_CONTENT"; then
   ASSIGNED_FORMAT="colon"
   log "Detected assigned.txt colon format (peerN: username)"
 fi
@@ -216,7 +252,7 @@ fi
 declare -A TAKEN=()
 while IFS= read -r line; do
   parse_assigned_line "$line" || continue
-  [[ -n "${PARSED_LABEL//[[:space:]]/}" ]] && TAKEN["$PARSED_PEER"]=1
+  peer_label_is_taken "$PARSED_LABEL" && TAKEN["$PARSED_PEER"]=1
 done <<<"$ASSIGNED_CONTENT"
 
 if [[ ${#TAKEN[@]} -gt 0 ]]; then
@@ -383,12 +419,17 @@ REMOTE_RECORD_ASSIGNMENT
 # ---- Reuse existing allocation for this env, if present (idempotent) -------
 find_assigned_peer() {
   local secret="$1"
-  awk -v env="$ENV_NAME" -v sec="($secret)" '
+  awk -v env="$ENV_NAME" -v secret="$secret" '
     $1 ~ /^peer[0-9]+:?$/ {
       peer=$1
       sub(/:$/, "", peer)
-      desc=substr($0, index($0,$2))
-      if (index(desc, env) && index(desc, sec)) { print peer; exit }
+      desc=$0
+      sub(/^[[:space:]]*peer[0-9]+[[:space:]]*:?[[:space:]]*/, "", desc)
+      suffix="(" secret ")"
+      if (length(desc) < length(suffix)) next
+      if (substr(desc, length(desc) - length(suffix) + 1) != suffix) next
+      label=substr(desc, 1, length(desc) - length(suffix))
+      if (label == env || index(label, env "(") == 1) { print peer; exit }
     }' <<<"$ASSIGNED_CONTENT"
 }
 
@@ -447,7 +488,7 @@ if [[ "$REUSED" != "true" ]]; then
 fi
 
 for p in "$TF_PEER" "$WG0_PEER" "$WG1_PEER"; do
-  if [[ -n "${TAKEN[$p]:-}" ]]; then
+  if [[ "$REUSED" != "true" && -n "${TAKEN[$p]:-}" ]]; then
     die "Refusing to allocate $p — already assigned in $ASSIGNED_FILE (script may have failed to read labels; check file format/permissions)"
   fi
 done
@@ -522,8 +563,9 @@ fi
 
 # ---- Create the GitHub environment + publish the three secrets -------------
 log "Ensuring GitHub environment '$ENV_NAME' exists ..."
+ENV_NAME_ENC="$(urlencode "$ENV_NAME")"
 gh api --method PUT -H "Accept: application/vnd.github+json" \
-  "repos/${REPO}/environments/${ENV_NAME}" >/dev/null
+  "repos/${REPO}/environments/${ENV_NAME_ENC}" >/dev/null
 
 log "Publishing environment secrets ..."
 printf '%s' "$TF_CONF"  | gh secret set TF_WG_CONFIG          --env "$ENV_NAME" --repo "$REPO" --body -
@@ -535,7 +577,7 @@ if [[ ! -f "$ALLOCATION_FILE" ]]; then
   printf 'env_name\ttf_peer\twg0_peer\twg1_peer\tallocated_at\n' > "$ALLOCATION_FILE"
 fi
 TMP="$(mktemp)"
-grep -vP "^${ENV_NAME}\t" "$ALLOCATION_FILE" > "$TMP" || true
+awk -F '\t' -v env="$ENV_NAME" 'NR == 1 || $1 != env' "$ALLOCATION_FILE" > "$TMP"
 printf '%s\t%s\t%s\t%s\t%s\n' "$ENV_NAME" "$TF_PEER" "$WG0_PEER" "$WG1_PEER" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$TMP"
 mv "$TMP" "$ALLOCATION_FILE"
 


### PR DESCRIPTION
This script automates the onboarding process for WireGuard in a new environment, handling peer allocation and configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added self-service WireGuard onboarding automation for a target environment, allocating and managing three distinct peers with reuse when available.
  * Fetches peer configs over SSH and rewrites them to match the configured CIDR requirements (including updating `AllowedIPs` and removing any `DNS` line).
  * Publishes the resulting configs as GitHub environment secrets, with **dry-run** preview support and rollback if secret publication fails.
  * Tracks allocations in a TSV file for auditing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->