### PR TITLE
fix: register WireGuard onboard workflow on master

### DIFF
--- a/.github/workflows/wg-onboard.yml
+++ b/.github/workflows/wg-onboard.yml
@@ -47,7 +47,7 @@ concurrency:
 
 jobs:
   onboard:
-    runs-on: self-hosted
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 20
     steps:
       - name: Validate required secrets


### PR DESCRIPTION
## Summary
- Removes `.github/workflows/wg-onboard.yml` with a trailing U+200E (invisible Unicode) character on `master`
- Replaces it with the clean workflow from `develop` so GitHub Actions registers **WireGuard onboard environment**

## Why
GitHub only lists `workflow_dispatch` workflows from the default branch (`master`). The corrupted filename was never parsed as a workflow, so nothing appeared under Actions after #253/#251 merged.

## Test plan
- [ ] Merge this PR
- [ ] Open **Actions → WireGuard onboard environment → Run workflow** on `master`
- [ ] Confirm `DRY_RUN: true` run starts on the `[self-hosted, Linux, X64]` runner


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to specify infrastructure constraints, ensuring consistent build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->