### PR TITLE
fixes: #1888 fix Mermaid diagram in README flow diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ graph TB
 
     %% Terraform Profile Selection
     PS{Select Terraform<br/>Profile}
-    PS -->|esignet-standalone| TF_ES[Terraform: infra<br/>profile: esignet-standalone<br/>4-node K8s cluster]
-    PS -->|mosip| TF_MP[Terraform: infra<br/>profile: mosip<br/>7-node K8s cluster]
+    PS -->|esignet-standalone| TF_ES[Terraform: infra<br/>profile: esignet-standalone]
+    PS -->|mosip| TF_MP[Terraform: infra<br/>profile: mosip]
 
     %% ── eSignet Standalone Flow — Helmsman profile: esignet ─────
     TF_ES --> ES_EXT[Helmsman: Prereqs + External<br/>profile: esignet-standalone]
@@ -52,7 +52,7 @@ graph TB
     ES_ESIGNET --> NS2[mosip-identity plugin]
     ES_ESIGNET --> NS4[sunbird-rc plugin]
 
-    NS1 --> ES_TRIGS[Helmsman: Testrigs<br/>4x eSignet testrigs]
+    NS1 --> ES_TRIGS[Helmsman: Testrigs]
     NS2 --> ES_TRIGS
     NS4 --> ES_TRIGS
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ graph TB
 
     %% Terraform Profile Selection
     PS{Select Terraform<br/>Profile}
-    PS -->|esignet(standalone)| TF_ES[Terraform: infra<br/>profile: esignet(standalone)<br/>4-node K8s cluster]
+    PS -->|esignet-standalone| TF_ES[Terraform: infra<br/>profile: esignet-standalone<br/>4-node K8s cluster]
     PS -->|mosip| TF_MP[Terraform: infra<br/>profile: mosip<br/>7-node K8s cluster]
 
     %% ── eSignet Standalone Flow — Helmsman profile: esignet ─────
-    TF_ES --> ES_EXT[Helmsman: Prereqs + External<br/>profile: esignet]
+    TF_ES --> ES_EXT[Helmsman: Prereqs + External<br/>profile: esignet-standalone]
     ES_EXT --> ES_ESIGNET[Helmsman: eSignet Standalone<br/>4 parallel namespaces]
 
     ES_ESIGNET --> NS1[esignet mock plugin]


### PR DESCRIPTION
## Summary
- Fix Mermaid parse error caused by parentheses in edge label (`esignet(standalone)` → `esignet-standalone`)
- Update stale `profile: esignet` label to `esignet-standalone` in flow diagram
- Remove opinionated wording (cluster node counts, testrig counts) from diagram nodes

## Test plan
- [ ] Verify Mermaid diagram renders correctly on GitHub README
- [ ] Confirm no other diagram labels reference old `esignet` profile name

Fixes: #1888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the deployment flow diagram labels for clearer Terraform profile selection and standalone eSignet deployment naming.
  * Simplified related diagram text by removing specific node and testrig counts, making the flow easier to read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->