### PR TITLE
Implement WireGuard config validation in script

### DIFF
--- a/.github/scripts/wg-env.sh
+++ b/.github/scripts/wg-env.sh
@@ -999,6 +999,32 @@ transform_conf() {
   '
 }
 
+validate_wireguard_conf() {
+  local label="$1" content="$2"
+  [[ ${#content} -ge 80 ]] \
+    || die "$label WireGuard config too short (${#content} bytes); expected a full peer conf"
+  grep -q '^\[Interface\]' <<<"$content" \
+    || die "$label WireGuard config missing [Interface] section"
+  grep -q '^\[Peer\]' <<<"$content" \
+    || die "$label WireGuard config missing [Peer] section"
+  grep -q '^[[:space:]]*PrivateKey[[:space:]]*=' <<<"$content" \
+    || die "$label WireGuard config missing PrivateKey"
+}
+
+# gh secret set --body - stores the literal character "-" (1 byte), not stdin.
+# Pass the conf via a temp file / stdin redirect instead.
+publish_env_secret() {
+  local name="$1" content="$2" tmp rc
+  validate_wireguard_conf "$name" "$content" || return 1
+  tmp="$(mktemp)"
+  chmod 600 "$tmp"
+  printf '%s\n' "$content" > "$tmp"
+  gh secret set "$name" --env "$ENV_NAME" --repo "$REPO" --app actions < "$tmp"
+  rc=$?
+  rm -f "$tmp"
+  return $rc
+}
+
 fetch_and_transform() {
   local peer="$1" raw
   local conf="$CONFIG_DIR/$peer/$peer.conf"
@@ -1055,8 +1081,8 @@ log "Publishing environment secrets ..."
 PEER_CONFS=("$TF_CONF" "$WG0_CONF" "$WG1_CONF")
 PUBLISHED_SECRETS=0
 for i in "${!SECRET_NAMES[@]}"; do
-  if printf '%s' "${PEER_CONFS[$i]}" \
-    | gh secret set "${SECRET_NAMES[$i]}" --env "$ENV_NAME" --repo "$REPO" --body -; then
+  log "Publishing ${SECRET_NAMES[$i]} (${#PEER_CONFS[$i]} bytes) ..."
+  if publish_env_secret "${SECRET_NAMES[$i]}" "${PEER_CONFS[$i]}"; then
     PUBLISHED_SECRETS=$((PUBLISHED_SECRETS + 1))
     log "Published ${SECRET_NAMES[$i]}"
   else

--- a/.github/scripts/wg-env.sh
+++ b/.github/scripts/wg-env.sh
@@ -1001,14 +1001,22 @@ transform_conf() {
 
 validate_wireguard_conf() {
   local label="$1" content="$2"
-  [[ ${#content} -ge 80 ]] \
-    || die "$label WireGuard config too short (${#content} bytes); expected a full peer conf"
-  grep -q '^\[Interface\]' <<<"$content" \
-    || die "$label WireGuard config missing [Interface] section"
-  grep -q '^\[Peer\]' <<<"$content" \
-    || die "$label WireGuard config missing [Peer] section"
-  grep -q '^[[:space:]]*PrivateKey[[:space:]]*=' <<<"$content" \
-    || die "$label WireGuard config missing PrivateKey"
+  if [[ ${#content} -lt 80 ]]; then
+    err "$label WireGuard config too short (${#content} bytes); expected a full peer conf"
+    return 1
+  fi
+  if ! grep -q '^\[Interface\]' <<<"$content"; then
+    err "$label WireGuard config missing [Interface] section"
+    return 1
+  fi
+  if ! grep -q '^\[Peer\]' <<<"$content"; then
+    err "$label WireGuard config missing [Peer] section"
+    return 1
+  fi
+  if ! grep -q '^[[:space:]]*PrivateKey[[:space:]]*=' <<<"$content"; then
+    err "$label WireGuard config missing PrivateKey"
+    return 1
+  fi
 }
 
 # gh secret set --body - stores the literal character "-" (1 byte), not stdin.
@@ -1016,9 +1024,12 @@ validate_wireguard_conf() {
 publish_env_secret() {
   local name="$1" content="$2" tmp rc
   validate_wireguard_conf "$name" "$content" || return 1
-  tmp="$(mktemp)"
-  chmod 600 "$tmp"
-  printf '%s\n' "$content" > "$tmp"
+  tmp="$(mktemp)" || return 1
+  chmod 600 "$tmp" || { rm -f "$tmp"; return 1; }
+  if ! printf '%s\n' "$content" > "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
   gh secret set "$name" --env "$ENV_NAME" --repo "$REPO" --app actions < "$tmp"
   rc=$?
   rm -f "$tmp"


### PR DESCRIPTION
Add validation for WireGuard configuration before publishing secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation before publishing environment secrets to prevent malformed WireGuard configurations from being stored.
  * Updated the secret publishing flow to use a safer temporary-file upload method, reducing the chance of failures.
* **Chores**
  * Enhanced onboarding logging to display the size (in bytes) of each configuration being published.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->