### PR TITLE
fixes: #1790 correct mock-identity-system config and fix README flow diagram

### DIFF
--- a/.github/workflows/helmsman_esignet.yml
+++ b/.github/workflows/helmsman_esignet.yml
@@ -42,6 +42,11 @@ on:
         description: "MOSIP-ID1 domain name for this environment (e.g. mosipenv1.xyz.net)"
         required: false
         type: string
+      enable_mosipid2:
+        description: "Enable MOSIP-ID2 eSignet instance (deploys softhsm, esignet, oidc-ui, mock-rp for mosipid2)"
+        required: false
+        default: false
+        type: boolean
       mosipid2_domain_name:
         description: "MOSIP-ID2 domain name for this environment (e.g. qabase.xyz.net)"
         required: false
@@ -50,11 +55,6 @@ on:
         description: "Environment name (e.g. sandbox, dev, staging)"
         required: false
         type: string
-      enable_mosipid2:
-        description: "Enable MOSIP-ID2 eSignet instance (deploys softhsm, esignet, oidc-ui, mock-rp for mosipid2)"
-        required: false
-        default: false
-        type: boolean
   push:
     paths:
       - Helmsman/dsf/**/esignet-dsf.yaml

--- a/Helmsman/dsf/esignet-standalone/esignet-dsf.yaml
+++ b/Helmsman/dsf/esignet-standalone/esignet-dsf.yaml
@@ -346,12 +346,21 @@ apps:
     version: 0.0.1-develop
     chart: mosip/mock-identity-system
     set:
+      image.repository: "mosipqa/mock-identity-system"
+      image.tag: "develop"
       valuesFile: "$WORKDIR/utils/mock-identity-values.yaml"
       enable_insecure: "false"
       extraEnvVarsCM[0]: "esignet-softhsm-share"
       extraEnvVarsCM[1]: "softhsm-mock-identity-system-share"
-      domainConfig.MOSIP_ESIGNET_HOST: "esignet.${domain_name}"
+      domainConfig.MOSIP_ESIGNET_HOST: "esignet-sunbird.${domain_name}"
+      domainConfig.MOSIP_SIGNUP_HOST: "signup-sunbird.${domain_name}"
+      domainConfig.MOSIP_API_HOST: "api.${domain_name}"
+      domainConfig.MOSIP_IAM_EXTERNAL_HOST: "iam.${domain_name}"
       domainConfig.MOSIP_API_INTERNAL_HOST: "api-internal.${domain_name}"
+      domainConfig.MOSIP_KAFKA_HOST: "kafka.${domain_name}"
+      domainConfig.MOSIP_POSTGRES_HOST: "postgres.${domain_name}"
+      domainConfig.MOSIP_SMTP_HOST: "smtp.${domain_name}"
+      domainConfig.installation-domain: "${domain_name}"
       domainConfig.MOSIP_MOCK_IDA_IDENTITY_SCHEMA_URL: "https://raw.githubusercontent.com/prathmeshj12/addidentityschema_testing/refs/heads/main/email-signup-schema-testing.json"
       domainConfig.MOSIP_MOCK_UI_SPEC_SCHEMA_URL: "https://raw.githubusercontent.com/prathmeshj12/addidentityschema_testing/refs/heads/main/ui_spec_reset_password_phone.json"
     timeout: 480

--- a/Helmsman/dsf/esignet-standalone/esignet-dsf.yaml
+++ b/Helmsman/dsf/esignet-standalone/esignet-dsf.yaml
@@ -346,6 +346,7 @@ apps:
     version: 0.0.1-develop
     chart: mosip/mock-identity-system
     set:
+      valuesFile: "$WORKDIR/utils/mock-identity-values.yaml"
       enable_insecure: "false"
       extraEnvVarsCM[0]: "esignet-softhsm-share"
       extraEnvVarsCM[1]: "softhsm-mock-identity-system-share"

--- a/Helmsman/dsf/esignet-standalone/esignet-dsf.yaml
+++ b/Helmsman/dsf/esignet-standalone/esignet-dsf.yaml
@@ -345,15 +345,14 @@ apps:
     enabled: true
     version: 0.0.1-develop
     chart: mosip/mock-identity-system
+    valuesFile: "$WORKDIR/utils/mock-identity-values.yaml"
     set:
       image.repository: "mosipqa/mock-identity-system"
       image.tag: "develop"
-      valuesFile: "$WORKDIR/utils/mock-identity-values.yaml"
       enable_insecure: "false"
-      extraEnvVarsCM[0]: "esignet-softhsm-share"
-      extraEnvVarsCM[1]: "softhsm-mock-identity-system-share"
-      domainConfig.MOSIP_ESIGNET_HOST: "esignet-sunbird.${domain_name}"
-      domainConfig.MOSIP_SIGNUP_HOST: "signup-sunbird.${domain_name}"
+      extraEnvVarsCM[0]: "softhsm-mock-identity-system-share"
+      domainConfig.MOSIP_ESIGNET_HOST: "esignet.${domain_name}"
+      domainConfig.MOSIP_SIGNUP_HOST: "signup.${domain_name}"
       domainConfig.MOSIP_API_HOST: "api.${domain_name}"
       domainConfig.MOSIP_IAM_EXTERNAL_HOST: "iam.${domain_name}"
       domainConfig.MOSIP_API_INTERNAL_HOST: "api-internal.${domain_name}"

--- a/Helmsman/utils/mock-identity-values.yaml
+++ b/Helmsman/utils/mock-identity-values.yaml
@@ -1,0 +1,50 @@
+extraEnvVars:
+  - name: DATABASE_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: mockid-postgres-config
+        key: database-host
+  - name: DATABASE_PORT
+    valueFrom:
+      configMapKeyRef:
+        name: mockid-postgres-config
+        key: database-port
+  - name: DATABASE_NAME
+    valueFrom:
+      configMapKeyRef:
+        name: mockid-postgres-config
+        key: database-name
+  - name: DATABASE_USERNAME
+    valueFrom:
+      configMapKeyRef:
+        name: mockid-postgres-config
+        key: database-username
+  - name: DB_DBUSER_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: db-common-secrets
+        key: db-dbuser-password
+  - name: SOFTHSM_MOCK_IDENTITY_SYSTEM_SECURITY_PIN
+    valueFrom:
+      secretKeyRef:
+        name: softhsm-mock-identity-system
+        key: security-pin
+  - name: hsm_local_dir_name
+    value: hsm-client
+  - name: MOSIP_ESIGNET_MOCK_SUPPORTED_FIELDS
+    value: individualId,password
+  - name: REDIS_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: redis-config
+        key: redis-host
+  - name: REDIS_PORT
+    valueFrom:
+      configMapKeyRef:
+        name: redis-config
+        key: redis-port
+  - name: REDIS_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: redis
+        key: redis-password

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ graph TB
 
     %% Terraform Profile Selection
     PS{Select Terraform<br/>Profile}
-    PS -->|esignet-standalone| TF_ES[Terraform: infra<br/>profile: esignet-standalone<br/>4-node K8s cluster]
-    PS -->|mosip| TF_MP[Terraform: infra<br/>profile: mosip<br/>7-node K8s cluster]
+    PS -->|esignet-standalone| TF_ES[Terraform: infra<br/>profile: esignet-standalone]
+    PS -->|mosip| TF_MP[Terraform: infra<br/>profile: mosip]
 
     %% ── eSignet Standalone Flow — Helmsman profile: esignet ─────
     TF_ES --> ES_EXT[Helmsman: Prereqs + External<br/>profile: esignet-standalone]
@@ -52,7 +52,7 @@ graph TB
     ES_ESIGNET --> NS2[mosip-identity plugin]
     ES_ESIGNET --> NS4[sunbird-rc plugin]
 
-    NS1 --> ES_TRIGS[Helmsman: Testrigs<br/>4x eSignet testrigs]
+    NS1 --> ES_TRIGS[Helmsman: Testrigs]
     NS2 --> ES_TRIGS
     NS4 --> ES_TRIGS
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ graph TB
 
     %% Terraform Profile Selection
     PS{Select Terraform<br/>Profile}
-    PS -->|esignet(standalone)| TF_ES[Terraform: infra<br/>profile: esignet(standalone)<br/>4-node K8s cluster]
+    PS -->|esignet-standalone| TF_ES[Terraform: infra<br/>profile: esignet-standalone<br/>4-node K8s cluster]
     PS -->|mosip| TF_MP[Terraform: infra<br/>profile: mosip<br/>7-node K8s cluster]
 
     %% ── eSignet Standalone Flow — Helmsman profile: esignet ─────
-    TF_ES --> ES_EXT[Helmsman: Prereqs + External<br/>profile: esignet]
+    TF_ES --> ES_EXT[Helmsman: Prereqs + External<br/>profile: esignet-standalone]
     ES_EXT --> ES_ESIGNET[Helmsman: eSignet Standalone<br/>4 parallel namespaces]
 
     ES_ESIGNET --> NS1[esignet mock plugin]


### PR DESCRIPTION
## Summary
- Fix Mermaid diagram parse error in README (`esignet(standalone)` → `esignet-standalone`) and remove opinionated wording (cluster sizes, testrig counts)
- Update `mock-identity-values.yaml` to override chart default `extraEnvVars`, removing `esignet-global` configmap dependency
- Move `valuesFile` to app level in mock-identity-system DSF (before `set:` values)
- Fix `extraEnvVarsCM` to use `softhsm-mock-identity-system-share` only (remove wrong `esignet-softhsm-share`)
- Fix `domainConfig.MOSIP_ESIGNET_HOST` / `MOSIP_SIGNUP_HOST` from sunbird URLs to correct esignet-mock URLs
- Reorder `enable_mosipid2` before `mosipid2_domain_name` in workflow inputs for better UI flow

## Test plan
- [ ] Verify README Mermaid diagram renders correctly on GitHub
- [ ] Verify mock-identity-system deploys without `esignet-global` dependency error
- [ ] Verify workflow UI shows `enable_mosipid2` toggle before `mosipid2_domain_name` field

Fixes: #1790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the deployment flow diagram to use clearer labels for the standalone eSignet path and related infrastructure steps.

* **Chores**
  * Adjusted deployment configuration for the mock identity system, including environment, host, and image settings.
  * Updated workflow input placement for the eSignet deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->