### PR TITLE
fix: remove softhsm PIN exposure from ConfigMap in postinstall hook

### DIFF
--- a/Helmsman/hooks/esignet-standalone/softhsm-mock-identity-system-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone/softhsm-mock-identity-system-postinstall.sh
@@ -2,28 +2,26 @@
 # =============================================================================
 # eSignet 1.7.1 - SoftHSM Mock Identity System Post-install
 # =============================================================================
-# Shares SoftHSM mock identity system configmap with esignet namespace.
+# Copies chart-generated softhsm-mock-identity-system-share configmap
+# (PKCS11 slot/token config) from softhsm namespace to esignet-mock namespace.
+# The security PIN is handled separately via secret copy in preinstall.
 # =============================================================================
 set -euo pipefail
+
+SOFTHSM_NS="${SOFTHSM_NS:-softhsm}"
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock}"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
 
 echo "================================================"
 echo "eSignet 1.7.1 - SoftHSM Mock Identity System Post-install"
 echo "================================================"
 
 # Wait for SoftHSM mock identity pod to be ready
-kubectl -n softhsm wait --for=condition=ready pod -l app.kubernetes.io/instance=softhsm-mock-identity-system --timeout=480s || \
+kubectl -n "$SOFTHSM_NS" wait --for=condition=ready pod -l app.kubernetes.io/instance=softhsm-mock-identity-system --timeout=480s || \
   { echo "ERROR: SoftHSM mock identity system pod not ready after timeout" >&2; exit 1; }
 
-# Share SoftHSM mock identity configmap with esignet-mock namespace
-MOCK_HSM_PIN=$(kubectl -n softhsm get secret softhsm-mock-identity-system -o jsonpath='{.data.security-pin}' 2>/dev/null || echo "")
-
-if [ -n "$MOCK_HSM_PIN" ]; then
-  kubectl -n esignet-mock create configmap softhsm-mock-identity-system-share \
-    --from-literal=softhsm-pin="$(echo -n "$MOCK_HSM_PIN" | base64 -d)" \
-    --dry-run=client -o yaml | kubectl apply -f -
-  echo "SoftHSM mock identity system credentials shared with esignet-mock namespace."
-else
-  echo "WARNING: SoftHSM mock identity system secret not found."
-fi
+# Copy chart-generated PKCS11 configmap to esignet-mock namespace
+echo "Copying softhsm-mock-identity-system-share configmap to $ESIGNET_NS"
+$COPY_UTIL configmap softhsm-mock-identity-system-share "$SOFTHSM_NS" "$ESIGNET_NS"
 
 echo "SoftHSM mock identity system post-install completed."


### PR DESCRIPTION
## Summary
- Fix security issue in `softhsm-mock-identity-system-postinstall.sh` where the SoftHSM security PIN was being decoded from the secret and stored as plaintext in a ConfigMap
- Replace with `copy_cm_func.sh` to copy the chart-generated PKCS11 configmap (`softhsm-mock-identity-system-share`) from `softhsm` namespace to `esignet-mock` namespace — same pattern used by `softhsm-esignet-postinstall.sh`
- The PIN is already securely handled via secret copy in `mock-identity-system-preinstall.sh` and read via `secretKeyRef` in `mock-identity-values.yaml`

## Test plan
- [ ] Verify `softhsm-mock-identity-system-share` ConfigMap in `esignet-mock` namespace contains only PKCS11 slot/token config (no PIN)
- [ ] Verify mock-identity-system pod starts successfully and reads PIN from secret

Fixes: #1790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-install setup to work reliably across configurable Kubernetes namespaces.
  * The installation flow now waits for the relevant service to be ready before copying shared configuration, reducing timing-related setup issues.
  * Removed the old fallback path for PIN handling during this step, aligning the process with the pre-install secret-copy flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->