### PR TITLE
docs: update esignet-standalone profile name and mosipid2 toggle across all guides

### DIFF
--- a/Helmsman/hooks/esignet-standalone/softhsm-mock-identity-system-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone/softhsm-mock-identity-system-postinstall.sh
@@ -2,28 +2,26 @@
 # =============================================================================
 # eSignet 1.7.1 - SoftHSM Mock Identity System Post-install
 # =============================================================================
-# Shares SoftHSM mock identity system configmap with esignet namespace.
+# Copies chart-generated softhsm-mock-identity-system-share configmap
+# (PKCS11 slot/token config) from softhsm namespace to esignet-mock namespace.
+# The security PIN is handled separately via secret copy in preinstall.
 # =============================================================================
 set -euo pipefail
+
+SOFTHSM_NS="${SOFTHSM_NS:-softhsm}"
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock}"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
 
 echo "================================================"
 echo "eSignet 1.7.1 - SoftHSM Mock Identity System Post-install"
 echo "================================================"
 
 # Wait for SoftHSM mock identity pod to be ready
-kubectl -n softhsm wait --for=condition=ready pod -l app.kubernetes.io/instance=softhsm-mock-identity-system --timeout=480s || \
+kubectl -n "$SOFTHSM_NS" wait --for=condition=ready pod -l app.kubernetes.io/instance=softhsm-mock-identity-system --timeout=480s || \
   { echo "ERROR: SoftHSM mock identity system pod not ready after timeout" >&2; exit 1; }
 
-# Share SoftHSM mock identity configmap with esignet-mock namespace
-MOCK_HSM_PIN=$(kubectl -n softhsm get secret softhsm-mock-identity-system -o jsonpath='{.data.security-pin}' 2>/dev/null || echo "")
-
-if [ -n "$MOCK_HSM_PIN" ]; then
-  kubectl -n esignet-mock create configmap softhsm-mock-identity-system-share \
-    --from-literal=softhsm-pin="$(echo -n "$MOCK_HSM_PIN" | base64 -d)" \
-    --dry-run=client -o yaml | kubectl apply -f -
-  echo "SoftHSM mock identity system credentials shared with esignet-mock namespace."
-else
-  echo "WARNING: SoftHSM mock identity system secret not found."
-fi
+# Copy chart-generated PKCS11 configmap to esignet-mock namespace
+echo "Copying softhsm-mock-identity-system-share configmap to $ESIGNET_NS"
+$COPY_UTIL configmap softhsm-mock-identity-system-share "$SOFTHSM_NS" "$ESIGNET_NS"
 
 echo "SoftHSM mock identity system post-install completed."

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ We've created comprehensive beginner-friendly guides to help you succeed:
 | **[Secret Generation Guide](docs/SECRET_GENERATION_GUIDE.md)**                                           | Step-by-step instructions to generate SSH keys, AWS credentials, GPG passwords, and more   | Before deployment - setup required secrets               |
 | **[Workflow Guide](docs/WORKFLOW_GUIDE.md)**                                                             | Visual walkthrough of GitHub Actions workflows with screenshots and navigation help        | During deployment - run workflows correctly               |
 | **[DSF Configuration Guide](docs/DSF_CONFIGURATION_GUIDE.md)**                                           | How to configure Helmsman files including clusterid and domain settings                    | Before Helmsman deployment - configure applications       |
-| **[eSignet Standalone Deployment Guide](docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md)**                   | Step-by-step guide to deploy eSignet standalone via GitHub Actions — secrets, variables, workflow order | eSignet standalone deployment |
+| **[eSignet Standalone Deployment Guide](docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md)**                   | End-to-end guide for eSignet standalone — Terraform infra provisioning, required AWS/GitHub secrets, tfvars setup, and Helmsman workflow order | eSignet standalone deployment |
 | **[Environment Destruction Guide](docs/ENVIRONMENT_DESTRUCTION_GUIDE.md)**                               | Safe teardown procedures, backup steps, and cost monitoring                                | After deployment - clean up resources                    |
 
 **Complete Documentation Index:** [View All Documentation](docs/README.md)

--- a/docs/DSF_CONFIGURATION_GUIDE.md
+++ b/docs/DSF_CONFIGURATION_GUIDE.md
@@ -31,7 +31,7 @@ DSF files are organized by **deployment profile** — not a single flat folder. 
 
 | Profile | Use Case |
 |---------|----------|
-| `esignet` | eSignet standalone (authentication only, no full MOSIP core services) |
+| `esignet-standalone` | eSignet standalone (authentication only, no full MOSIP core services) |
 | `mosip-platform-1.2.0.x` | Full MOSIP platform with Java 11 |
 | `mosip-platform-1.2.1.x` | Full MOSIP platform with Java 21 |
 
@@ -64,8 +64,8 @@ Helmsman/dsf/
 | `prereq-dsf.yaml` | Monitoring, Istio, logging | 1st |
 | `external-dsf.yaml` | Databases, queues, storage, Keycloak | 2nd |
 | `mosip-dsf.yaml` | MOSIP core services (MOSIP platform profiles only) | 3rd |
-| `esignet-dsf.yaml` | eSignet stack + OIDC UI + Mock RP | 4th (or 3rd for esignet profile) |
-| `signup-dsf.yaml` | Signup stack (esignet profile only) | 5th (auto-triggered) |
+| `esignet-dsf.yaml` | eSignet stack + OIDC UI + Mock RP | 4th (or 3rd for esignet-standalone profile) |
+| `signup-dsf.yaml` | Signup stack (esignet-standalone profile only) | 5th (auto-triggered) |
 | `testrigs-dsf.yaml` | Testing infrastructure | Last (optional) |
 
 ### Environment Variable Substitution
@@ -719,7 +719,7 @@ apps:
 
 - [ ] All MOSIP/eSignet services running
 - [ ] Test data branch matches MOSIP version
-- [ ] `vars.MOSIPID1_DOMAIN_NAME` and `vars.MOSIPID2_DOMAIN_NAME` set (esignet profile)
+- [ ] `vars.MOSIPID1_DOMAIN_NAME` and `vars.MOSIPID2_DOMAIN_NAME` set (esignet-standalone profile)
 
 ---
 
@@ -795,8 +795,8 @@ apps:
 | Slack channel | `vars.SLACK_CHANNEL_NAME` | GitHub Environment Variables | Alerting in prereq-dsf |
 | MOSIP postgres port | `vars.DB_PORT` | GitHub Environment Variables | MOSIP platform external postgres (5433) |
 | eSignet postgres port | `vars.ESIGNET_DB_PORT` | GitHub Environment Variables | eSignet container postgres (5432) |
-| MOSIP-ID1 domain | `vars.MOSIPID1_DOMAIN_NAME` | GitHub Environment Variables | esignet profile — MOSIP-ID1 testrig hosts |
-| MOSIP-ID2 domain | `vars.MOSIPID2_DOMAIN_NAME` | GitHub Environment Variables | esignet profile — MOSIP-ID2 testrig hosts |
+| MOSIP-ID1 domain | `vars.MOSIPID1_DOMAIN_NAME` | GitHub Environment Variables | esignet-standalone profile — MOSIP-ID1 testrig hosts |
+| MOSIP-ID2 domain | `vars.MOSIPID2_DOMAIN_NAME` | GitHub Environment Variables | esignet-standalone profile — MOSIP-ID2 testrig hosts |
 
 **DSF file manual edits (one-time per environment):**
 

--- a/docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md
+++ b/docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md
@@ -213,12 +213,13 @@ Step 4 → Deploy Testrigs (optional) (helmsman_testrigs.yml)   ~10 min
 The Terraform workflow has three separate components. Run them in this order:
 
 ```
-0a → base-infra     (once per AWS account — shared networking layer)
-0b → observ-infra   (optional — separate monitoring cluster)
-0c → infra          (profile: esignet-standalone — the main eSignet cluster)
+0b → base-infra     (once per AWS account — skip if already done)
+0c → observ-infra   (optional — skip if not needed or already done)
+0d → infra          (profile: esignet-standalone — always required)
 ```
 
-> **Already have `base-infra` deployed?** Skip `0a` and go straight to `0b` or `0c`.
+> **Already have `base-infra` deployed?** Skip `0b` entirely — go straight to `0c` or `0d`.
+> **Already have `observ-infra` deployed (or don't need it)?** Skip `0c` — go straight to `0d`.
 
 **Terraform workflow name:** `terraform plan / apply`
 

--- a/docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md
+++ b/docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md
@@ -129,7 +129,8 @@ Path to create `GH_INFRA_PAT`: `Your profile → Settings → Developer settings
 | Secret Name | What it is | Notes |
 |---|---|---|
 | `KUBECONFIG` | Raw kubeconfig YAML for your cluster | Paste the raw YAML — **do not** base64 encode it. Generated after Terraform apply completes. |
-| `CLUSTER_WIREGUARD_WG0` | WireGuard VPN client config for Helmsman runner | Different from `TF_WG_CONFIG` — this is the Helmsman runner's peer config. See [Secret Generation Guide](SECRET_GENERATION_GUIDE.md). |
+| `CLUSTER_WIREGUARD_WG0` | WireGuard VPN client config for Helmsman runner (interface 0) | Different from `TF_WG_CONFIG` — this is the Helmsman runner's peer config. See [Secret Generation Guide](SECRET_GENERATION_GUIDE.md). |
+| `CLUSTER_WIREGUARD_WG1` | WireGuard VPN client config for Helmsman runner (interface 1) | Second WireGuard interface — required alongside `WG0`. See [Secret Generation Guide](SECRET_GENERATION_GUIDE.md). |
 
 **For `helmsman_external.yml` (profile = `esignet-standalone`):**
 
@@ -281,7 +282,7 @@ Follow the full instructions in the root README: [Step 3ca: Observation Infrastr
 
 2. **After apply completes (~20 min):** Retrieve the kubeconfig from the cluster and add it as the `KUBECONFIG` environment secret (Section 2B) before proceeding to Step 1.
 
-> **Note on WireGuard:** The Terraform runner connects to the nginx node via `TF_WG_CONFIG` (repository secret) to run post-provisioning scripts. `CLUSTER_WIREGUARD_WG0` (environment secret) is separate — it is used by Helmsman workflows to reach the cluster API. Both must be configured before their respective workflows run.
+> **Note on WireGuard:** The Terraform runner connects to the nginx node via `TF_WG_CONFIG` (repository secret) to run post-provisioning scripts. `CLUSTER_WIREGUARD_WG0` and `CLUSTER_WIREGUARD_WG1` (environment secrets) are separate — they are used by Helmsman workflows to reach the cluster API. All three must be configured before their respective workflows run.
 
 ---
 

--- a/docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md
+++ b/docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md
@@ -29,6 +29,7 @@ You do **not** need to run any commands on your local machine — everything run
    - [Step 4 — Deploy Testrigs (optional)](#step-4--deploy-testrigs-optional)
 5. [Re-deploying or Re-running](#4-re-deploying-or-re-running)
 6. [Verifying Deployment](#5-verifying-deployment)
+7. [MOSIP ID Plugin Onboarding (mosipid1 / mosipid2)](#6-mosip-id-plugin-onboarding-mosipid1--mosipid2)
 
 ---
 
@@ -459,3 +460,62 @@ kubectl get pods --all-namespaces | grep -v Running | grep -v Completed | grep -
 | MOSIP-ID1 eSignet | `https://esignet-mosipid1.sandbox.xyz.net` |
 | MOSIP-ID2 eSignet | `https://esignet-mosipid2.sandbox.xyz.net` |
 | Sunbird eSignet | `https://esignet-sunbird.sandbox.xyz.net` |
+
+---
+
+## 6. MOSIP ID Plugin Onboarding (mosipid1 / mosipid2)
+
+> **This section applies only if you are deploying `esignet-mosipid1` or `esignet-mosipid2`** — instances that authenticate citizens against a real MOSIP platform. If you are using only the mock identity system (`esignet-mock`) or Sunbird, skip this section.
+
+Onboarding eSignet to a MOSIP identity system involves two phases: **prerequisites** (config changes on the MOSIP platform side) and **manual onboarding** (Postman collection run against the deployed eSignet instance).
+
+---
+
+### Prerequisites — Changes on the MOSIP platform's mosip-config branch
+
+The following changes must be made on **each MOSIP platform's `mosip-config` repository branch** that the esignet-mosipid instance points to (the branch set via `ESIGNET_MOSIPID1_SPRING_CONFIG_LABEL` / `ESIGNET_MOSIPID2_SPRING_CONFIG_LABEL`).
+
+#### 1. Add eSignet property files
+
+The MOSIP platform's `mosip-config` branch must contain eSignet-specific property files for the `mosipid` Spring profile. Add the following files if they are not already present:
+
+- `application-mosipid.properties` — application-level config for the mosipid profile
+- `esignet-mosipid.properties` — eSignet service config for the mosipid profile
+
+Reference commit: [mosip/mosip-config@e8961a2](https://github.com/mosip/mosip-config/commit/e8961a289d9acffc581df20875ffaabc2f2d3534)
+
+> Copy these files from the reference commit into your MOSIP platform's `mosip-config` branch.
+
+#### 2. Allow eSignet domains in IDA configuration
+
+The MOSIP Identity Authentication service restricts which domains can call its APIs. Edit `id-authentication-default.properties` in the MOSIP platform's `mosip-config` branch and add your eSignet standalone hostnames to `mosip.ida.allowed.domain.uris`:
+
+**For mosipid1 only:**
+```properties
+mosip.ida.allowed.domain.uris=${mosip.api.internal.url},https://${mosip.esignet.host},https://esignet-mosipid1.<your-domain>
+```
+
+**For both mosipid1 and mosipid2:**
+```properties
+mosip.ida.allowed.domain.uris=${mosip.api.internal.url},https://${mosip.esignet.host},https://esignet-mosipid1.<your-domain>,https://esignet-mosipid2.<your-domain>
+```
+
+Replace `<your-domain>` with your eSignet standalone base domain (e.g. `sandbox.xyz.net`).
+
+Reference commit: [mosip/mosip-config@27276cb](https://github.com/mosip/mosip-config/commit/27276cbb7fa01015492855baa3e00fe0a4db421c)
+
+After committing these changes, restart the `id-authentication` pods on the MOSIP platform so the config server picks up the new values:
+
+```bash
+kubectl rollout restart deployment -n ida
+```
+
+---
+
+### Manual Onboarding — eSignet Postman Collection
+
+Once the prerequisites above are complete, follow the manual onboarding steps using the eSignet Postman collection:
+
+**[eSignet Postman Collection — MOSIP ID Plugin Onboarding](https://github.com/mosip/esignet/tree/master/postman-collection#esignet-collection)**
+
+This collection covers partner onboarding, OIDC client registration, and end-to-end flow verification for the MOSIP ID plugin against your deployed `esignet-mosipid1` or `esignet-mosipid2` instance.

--- a/docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md
+++ b/docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md
@@ -9,7 +9,7 @@ You do **not** need to run any commands on your local machine — everything run
 - Mock Relying Party service and UI
 - Supporting infrastructure: Postgres, Redis, Kafka, Keycloak, SoftHSM, Captcha, MinIO
 
-**Estimated time:** ~45–60 minutes end to end (external services ~20 min, eSignet ~25 min).
+**Estimated time:** ~90–120 minutes end to end (Terraform ~30 min, external services ~20 min, eSignet ~25 min).
 
 ---
 
@@ -17,10 +17,12 @@ You do **not** need to run any commands on your local machine — everything run
 
 1. [Understanding the eSignet Instances](#0-understanding-the-esignet-instances)
 2. [Before You Start](#1-before-you-start)
-3. [One-time GitHub Environment Setup](#2-one-time-github-environment-setup)
-   - [Secrets](#a-secrets)
-   - [Environment Variables](#b-environment-variables)
+3. [One-time GitHub Setup](#2-one-time-github-setup)
+   - [Repository Secrets](#a-repository-secrets--required-by-all-workflows)
+   - [Environment Secrets](#b-environment-secrets--configured-per-branch)
+   - [Environment Variables](#c-environment-variables)
 4. [Deployment Steps](#3-deployment-steps)
+   - [Step 0 — Provision Infrastructure (Terraform)](#step-0--provision-infrastructure-terraform)
    - [Step 1 — Deploy External Services](#step-1--deploy-external-services)
    - [Step 2 — Deploy eSignet](#step-2--deploy-esignet)
    - [Step 3 — Deploy Signup (in progress)](#step-3--deploy-signup)
@@ -85,7 +87,7 @@ Complete this checklist before triggering any workflow:
 
 ---
 
-## 2. One-time GitHub Environment Setup
+## 2. One-time GitHub Setup
 
 GitHub has two places to store secrets. It is important to put each secret in the **right place** — putting a secret in the wrong place will cause the workflow to fail.
 
@@ -96,39 +98,40 @@ GitHub has two places to store secrets. It is important to put each secret in th
 
 ---
 
-### A. Secrets
+### A. Repository Secrets — required by all workflows
 
-> Secrets are sensitive values (passwords, keys, tokens). They are masked in logs.
+> Configure these once under `Settings → Secrets and variables → Actions → Repository secrets`.
 
-#### Repository Secret — one secret, configured once for the whole repo
+| Secret Name | What it is | Notes |
+|---|---|---|
+| `GH_INFRA_PAT` | GitHub Fine-grained Personal Access Token | **Contents**: R/W · **Actions**: R/W · **Environments**: R/W · **Variables**: R/W · **Metadata**: R/O. Used by Helmsman workflows to update env vars and dispatch signup. See [Secret Generation Guide](SECRET_GENERATION_GUIDE.md). |
+| `AWS_ACCESS_KEY_ID` | AWS IAM access key ID | Used by the Terraform workflow to create/manage AWS resources |
+| `AWS_SECRET_ACCESS_KEY` | AWS IAM secret access key | Paired with `AWS_ACCESS_KEY_ID` |
+| `GPG_PASSPHRASE` | Passphrase for encrypting Terraform state | Terraform state files are GPG-encrypted before being committed to the repo when using local backend |
+| `TF_WG_CONFIG` | WireGuard client config for Terraform runner | Terraform connects to the nginx node via WireGuard VPN to run post-provisioning scripts. Paste the raw `wg0.conf` content — **not** base64 encoded. See [Secret Generation Guide](SECRET_GENERATION_GUIDE.md). |
+| `SLACK_WEBHOOK_URL` | Slack incoming webhook URL | Used by Terraform and Helmsman for failure/success notifications |
 
-| Secret Name | What it is | Required scopes | How to create |
-|---|---|---|---|
-| `GH_INFRA_PAT` | GitHub Fine-grained Personal Access Token | **Contents**: Read and write<br>**Actions**: Read and write<br>**Environments**: Read and write<br>**Variables**: Read and write<br>**Metadata**: Read-only | GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens |
+> ⚠️ **Common `GH_INFRA_PAT` mistake:** Using a Classic token, or setting `Contents` to Read-only — both cause a `403` when the workflow tries to push commits or update environment variables. Always use Fine-grained tokens.
 
-**Why `GH_INFRA_PAT` is a repository secret (not environment secret):**
-It is used to save workflow inputs back to environment variables via the GitHub API, and to dispatch the signup workflow. It needs to work across environments so it lives at the repo level.
-
-> ⚠️ **Common mistake:** Using a Classic token instead of a Fine-grained token, or setting `Contents` to Read-only — both cause a `403` error when the workflow tries to push commits or update environment variables.
-
-Path to create: `Your profile → Settings → Developer settings → Personal access tokens → Fine-grained tokens → Generate new token`
+Path to create `GH_INFRA_PAT`: `Your profile → Settings → Developer settings → Personal access tokens → Fine-grained tokens → Generate new token`
 - **Resource owner**: your organisation (e.g. `mosip`)
 - **Repository access**: Only select repositories → choose this infra repo
 - Set the permissions listed above, then generate and copy the token
 
 ---
 
-#### Environment Secrets — configured per branch under `Settings → Environments → <branch-name> → Secrets`
+### B. Environment Secrets — configured per branch
+
+> Configure these under `Settings → Environments → <your-branch-name> → Secrets`.
 
 **Cluster access — required by all Helmsman workflows:**
 
 | Secret Name | What it is | Notes |
 |---|---|---|
-| `KUBECONFIG` | Raw kubeconfig YAML | Paste the raw YAML — **do not** base64 encode it |
-| `CLUSTER_WIREGUARD_WG0` | WireGuard VPN client config | See [Secret Generation Guide](SECRET_GENERATION_GUIDE.md) |
-| `SLACK_WEBHOOK_URL` | Slack incoming webhook URL | From your Slack app's Incoming Webhooks settings |
+| `KUBECONFIG` | Raw kubeconfig YAML for your cluster | Paste the raw YAML — **do not** base64 encode it. Generated after Terraform apply completes. |
+| `CLUSTER_WIREGUARD_WG0` | WireGuard VPN client config for Helmsman runner | Different from `TF_WG_CONFIG` — this is the Helmsman runner's peer config. See [Secret Generation Guide](SECRET_GENERATION_GUIDE.md). |
 
-**For `helmsman_external.yml` (profile = `esignet`):**
+**For `helmsman_external.yml` (profile = `esignet-standalone`):**
 
 | Secret Name | What it is |
 |---|---|
@@ -163,7 +166,7 @@ Path to create: `Your profile → Settings → Developer settings → Personal a
 
 ---
 
-### B. Environment Variables
+### C. Environment Variables
 
 > Variables are non-sensitive configuration values visible in workflow logs.
 
@@ -186,14 +189,84 @@ Navigate to: `Repository → Settings → Environments → <your-branch-name> �
 
 ## 3. Deployment Steps
 
-There are **4 steps** in total. Run them in the order shown below. **Do not start the next step until the current one shows a green tick (✅) in GitHub Actions.**
+There are **5 steps** in total. Run them in the order shown below. **Do not start the next step until the current one shows a green tick (✅) in GitHub Actions.**
 
 ```
+Step 0 → Provision Infrastructure   (terraform.yml)           ~30 min  ← skip if cluster already exists
 Step 1 → Deploy External Services   (helmsman_external.yml)   ~20 min
 Step 2 → Deploy eSignet             (helmsman_esignet.yml)    ~25 min
 Step 3 → Deploy Signup              (helmsman_signup.yml)     ⚠️  IN PROGRESS — not ready yet
 Step 4 → Deploy Testrigs (optional) (helmsman_testrigs.yml)   ~10 min
 ```
+
+---
+
+### Step 0 — Provision Infrastructure (Terraform)
+
+> **What this does:** Creates the AWS infrastructure your cluster will run on — VPC, networking, EC2 nodes, WireGuard jump server, and the RKE2 Kubernetes cluster itself.
+> **Skip this step** if your cluster already exists. Jump straight to Step 1.
+
+**Terraform workflow name:** `terraform plan / apply`
+
+#### 0a — Update the tfvars file
+
+Before running the workflow, fill in the placeholders in the tfvars file for the `esignet-standalone` profile:
+
+**File:** `terraform/implementations/aws/infra/profiles/esignet-standalone/aws.tfvars`
+
+| Field | What to set |
+|---|---|
+| `cluster_name` | A short name for your cluster (e.g. `esignet-sandbox`) |
+| `cluster_env_domain` | Your base domain (e.g. `sandbox.xyz.net`) |
+| `mosip_email_id` | Email address for SSL certificate expiry alerts from Certbot |
+| `ssh_key_name` | Name of the AWS key pair to use for SSH access to nodes |
+| `zone_id` | Your Route 53 hosted zone ID for this domain |
+| `vpc_name` | Name of your existing VPC (looked up by `Name` tag) |
+| `rancher_import_url` | Rancher import URL for this cluster (from Rancher UI → Cluster → Registration) |
+| `aws_provider_region` | AWS region to deploy into (default: `ap-south-1`) |
+
+All other fields (node counts, instance types, volume sizes) are already set to sensible defaults for eSignet standalone. Review and adjust if needed.
+
+Commit the updated file on your branch before triggering the workflow.
+
+#### 0b — Run: Base Infrastructure (first time only)
+
+> Run this once per AWS account/VPC. It creates the shared base networking layer.
+
+**GitHub Actions workflow name:** `terraform plan / apply`
+
+1. Go to **Actions** → click **`terraform plan / apply`**
+2. Click **`Run workflow`** and fill in:
+
+| Field | Value |
+|---|---|
+| `cloud_provider` | `aws` |
+| `component` | `base-infra` |
+| `profile` | *(leave as default — `mosip`, ignored for `base-infra`)* |
+| `backend` | `local` *(or `s3` if you have a remote backend bucket)* |
+| `SSH_PRIVATE_KEY` | The **name** of the GitHub secret that holds your SSH private key (e.g. `SSH_PRIVATE_KEY`) |
+| `terraform_apply` | Leave **unticked** for plan-only first; tick to apply |
+
+3. Review the plan output in the workflow log, then re-run with `terraform_apply` ticked.
+
+#### 0c — Run: Main Infrastructure
+
+> This creates the Kubernetes nodes and the cluster itself.
+
+1. Trigger **`terraform plan / apply`** again with:
+
+| Field | Value |
+|---|---|
+| `cloud_provider` | `aws` |
+| `component` | `infra` |
+| `profile` | `esignet-standalone` |
+| `backend` | `local` *(or `s3`)* |
+| `SSH_PRIVATE_KEY` | Name of your SSH private key secret (e.g. `SSH_PRIVATE_KEY`) |
+| `terraform_apply` | Tick to apply |
+
+2. **After apply completes (~20 min):** Terraform will have created the cluster. Retrieve the kubeconfig from the cluster and add it as the `KUBECONFIG` environment secret (Section 2B) before proceeding.
+
+> **Note on WireGuard:** The Terraform runner connects to the nginx node via `TF_WG_CONFIG` (repository secret) to run post-provisioning scripts. `CLUSTER_WIREGUARD_WG0` (environment secret) is separate — it is used by Helmsman workflows to reach the cluster API. Both must be configured before their respective workflows run.
 
 ---
 
@@ -303,12 +376,12 @@ All pods should show `Running`.
 
 | Field | Value to enter |
 |---|---|
-| `profile` | `esignet` |
+| `profile` | `esignet-standalone` |
 | `mode` | `apply` |
 | `domain_name` | your base domain — e.g. `sandbox.xyz.net` |
 | `mosipid1_domain_name` | MOSIP-ID1 base domain *(if MOSIP-ID1 was deployed in Step 2)* |
-| `mosipid2_domain_name` | MOSIP-ID2 base domain *(if MOSIP-ID2 was deployed in Step 2)* |
-| `db_port` *(MOSIP platform external postgres)* | leave blank — not used by the `esignet` profile |
+| `mosipid2_domain_name` | MOSIP-ID2 base domain *(if `enable_mosipid2` was `true` in Step 2)* |
+| `db_port` *(MOSIP platform external postgres)* | leave blank — not used by the `esignet-standalone` profile |
 | `esignet_db_port` *(esignet container postgres)* | `5432` |
 | `env_name` | your environment name |
 | `slack_channel_name` | your Slack channel |

--- a/docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md
+++ b/docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md
@@ -192,7 +192,10 @@ Navigate to: `Repository → Settings → Environments → <your-branch-name> �
 There are **5 steps** in total. Run them in the order shown below. **Do not start the next step until the current one shows a green tick (✅) in GitHub Actions.**
 
 ```
-Step 0 → Provision Infrastructure   (terraform.yml)           ~30 min  ← skip if cluster already exists
+Step 0 → Provision Infrastructure   (terraform plan / apply)
+  ├── 0b  base-infra      ~10 min   ← once per AWS account; skip if already done
+  ├── 0c  observ-infra    ~15 min   ← optional monitoring cluster
+  └── 0d  infra           ~20 min   profile: esignet-standalone  ← the main cluster
 Step 1 → Deploy External Services   (helmsman_external.yml)   ~20 min
 Step 2 → Deploy eSignet             (helmsman_esignet.yml)    ~25 min
 Step 3 → Deploy Signup              (helmsman_signup.yml)     ⚠️  IN PROGRESS — not ready yet
@@ -206,11 +209,23 @@ Step 4 → Deploy Testrigs (optional) (helmsman_testrigs.yml)   ~10 min
 > **What this does:** Creates the AWS infrastructure your cluster will run on — VPC, networking, EC2 nodes, WireGuard jump server, and the RKE2 Kubernetes cluster itself.
 > **Skip this step** if your cluster already exists. Jump straight to Step 1.
 
+The Terraform workflow has three separate components. Run them in this order:
+
+```
+0a → base-infra     (once per AWS account — shared networking layer)
+0b → observ-infra   (optional — separate monitoring cluster)
+0c → infra          (profile: esignet-standalone — the main eSignet cluster)
+```
+
+> **Already have `base-infra` deployed?** Skip `0a` and go straight to `0b` or `0c`.
+
 **Terraform workflow name:** `terraform plan / apply`
+
+---
 
 #### 0a — Update the tfvars file
 
-Before running the workflow, fill in the placeholders in the tfvars file for the `esignet-standalone` profile:
+Before running the workflow, fill in the placeholders in the `esignet-standalone` tfvars file:
 
 **File:** `terraform/implementations/aws/infra/profiles/esignet-standalone/aws.tfvars`
 
@@ -229,31 +244,31 @@ All other fields (node counts, instance types, volume sizes) are already set to 
 
 Commit the updated file on your branch before triggering the workflow.
 
+---
+
 #### 0b — Run: Base Infrastructure (first time only)
 
-> Run this once per AWS account/VPC. It creates the shared base networking layer.
+> **One-time per AWS account.** Creates the shared base networking layer — VPC, subnets, WireGuard jump server. If `base-infra` has already been deployed for this AWS account, skip to `0c`.
 
-**GitHub Actions workflow name:** `terraform plan / apply`
+Follow the full instructions in the root README: [Step 3a: Base Infrastructure](../README.md#step-3a-base-infrastructure)
 
-1. Go to **Actions** → click **`terraform plan / apply`**
-2. Click **`Run workflow`** and fill in:
+After `base-infra` completes, configure `TF_WG_CONFIG` (repository secret) with your WireGuard client config before proceeding — see [WireGuard VPN Setup](../README.md#step-3b-wireguard-vpn-setup-required-for-private-network-access).
 
-| Field | Value |
-|---|---|
-| `cloud_provider` | `aws` |
-| `component` | `base-infra` |
-| `profile` | *(leave as default — `mosip`, ignored for `base-infra`)* |
-| `backend` | `local` *(or `s3` if you have a remote backend bucket)* |
-| `SSH_PRIVATE_KEY` | The **name** of the GitHub secret that holds your SSH private key (e.g. `SSH_PRIVATE_KEY`) |
-| `terraform_apply` | Leave **unticked** for plan-only first; tick to apply |
+---
 
-3. Review the plan output in the workflow log, then re-run with `terraform_apply` ticked.
+#### 0c — Run: Observability Infrastructure (optional)
 
-#### 0c — Run: Main Infrastructure
+> **Optional.** Creates a separate lightweight Kubernetes cluster for monitoring and observability tooling (Rancher, Keycloak, logging). eSignet standalone works without it — skip if you don't need a dedicated monitoring cluster.
 
-> This creates the Kubernetes nodes and the cluster itself.
+Follow the full instructions in the root README: [Step 3ca: Observation Infrastructure](../README.md#step-3ca-observation-infrastructure-observ-infra--optional)
 
-1. Trigger **`terraform plan / apply`** again with:
+---
+
+#### 0d — Run: Main Infrastructure
+
+> Creates the Kubernetes nodes and cluster for eSignet standalone. Run this after `base-infra` (and optionally `observ-infra`) are complete.
+
+1. Trigger **`terraform plan / apply`** with:
 
 | Field | Value |
 |---|---|
@@ -261,10 +276,10 @@ Commit the updated file on your branch before triggering the workflow.
 | `component` | `infra` |
 | `profile` | `esignet-standalone` |
 | `backend` | `local` *(or `s3`)* |
-| `SSH_PRIVATE_KEY` | Name of your SSH private key secret (e.g. `SSH_PRIVATE_KEY`) |
+| `SSH_PRIVATE_KEY` | Name of your SSH private key secret |
 | `terraform_apply` | Tick to apply |
 
-2. **After apply completes (~20 min):** Terraform will have created the cluster. Retrieve the kubeconfig from the cluster and add it as the `KUBECONFIG` environment secret (Section 2B) before proceeding.
+2. **After apply completes (~20 min):** Retrieve the kubeconfig from the cluster and add it as the `KUBECONFIG` environment secret (Section 2B) before proceeding to Step 1.
 
 > **Note on WireGuard:** The Terraform runner connects to the nginx node via `TF_WG_CONFIG` (repository secret) to run post-provisioning scripts. `CLUSTER_WIREGUARD_WG0` (environment secret) is separate — it is used by Helmsman workflows to reach the cluster API. Both must be configured before their respective workflows run.
 

--- a/docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md
+++ b/docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md
@@ -177,7 +177,7 @@ Navigate to: `Repository → Settings → Environments → <your-branch-name> �
 | `DOMAIN_NAME` | `sandbox.xyz.net` | **Yes** | Base domain — all service hostnames are built from this |
 | `ESIGNET_DB_PORT` | `5432` | **Yes** | Postgres port — always `5432` for standalone |
 | `ENV_NAME` | `sandbox` | **Yes** | Short environment label shown on the landing page |
-| `CLUSTER_ID` | `c-xxxxx` | **Yes** | Rancher cluster ID used by monitoring setup |
+| `CLUSTER_ID` | `c-xxxxx` | **Yes** | Rancher cluster ID used by monitoring setup — see [Finding your clusterid](../README.md#step-4a-configure-github-environment-variables) in the root README |
 | `SLACK_CHANNEL_NAME` | `#mosip-alerts` | **Yes** | Slack channel name for alert notifications |
 | `MOSIPID1_DOMAIN_NAME` | `mosipid1.xyz.net` | Optional | Base domain of the MOSIP environment that `esignet-mosipid1` connects to (required if mosipid1 is enabled) |
 | `MOSIPID2_DOMAIN_NAME` | `mosipid2.xyz.net` | Optional | Base domain of the second MOSIP environment — only set this if you have enabled mosipid2 (see [Section 0](#0-understanding-the-esignet-instances)) |
@@ -237,7 +237,7 @@ Before running the workflow, fill in the placeholders in the `esignet-standalone
 | `ssh_key_name` | Name of the AWS key pair to use for SSH access to nodes |
 | `zone_id` | Your Route 53 hosted zone ID for this domain |
 | `vpc_name` | Name of your existing VPC (looked up by `Name` tag) |
-| `rancher_import_url` | Rancher import URL for this cluster (from Rancher UI → Cluster → Registration) |
+| `rancher_import_url` | Rancher import URL for this cluster — see [Rancher Import Configuration](../README.md#rancher-import-configuration-optional) in the root README for where to find this URL and how to escape it correctly |
 | `aws_provider_region` | AWS region to deploy into (default: `ap-south-1`) |
 
 All other fields (node counts, instance types, volume sizes) are already set to sensible defaults for eSignet standalone. Review and adjust if needed.

--- a/docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md
+++ b/docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md
@@ -55,12 +55,13 @@ If you only have one MOSIP system to connect to, leave mosipid2 disabled. You do
 
 **To enable mosipid2:**
 
-1. In `Helmsman/dsf/esignet/esignet-dsf.yaml`, find the mosipid2 app blocks and change `enabled: false` → `enabled: true` for each
-2. Add the `MOSIPID2_DOMAIN_NAME` environment variable in your GitHub Environment (Section 2B)
-3. Add these secrets in your GitHub Environment (Section 2A):
+1. Add the `MOSIPID2_DOMAIN_NAME` environment variable in your GitHub Environment (Section 2B)
+2. Add these secrets in your GitHub Environment (Section 2A):
    - `ESIGNET_MOSIPID2_CAPTCHA_SITE_KEY` and `ESIGNET_MOSIPID2_CAPTCHA_SECRET_KEY`
    - `MOSIPID2_POSTGRES_PASSWORD` and `MOSIPID2_KEYCLOAK_ADMIN_PASSWORD`
-4. Provide the `mosipid2_domain_name` input when running the eSignet workflow (Step 2)
+3. When running the eSignet workflow (Step 2), toggle **`enable_mosipid2`** to `true` and fill in the `mosipid2_domain_name` field
+
+> No DSF file edits needed — `enable_mosipid2` is a workflow input toggle that controls deployment at runtime.
 
 ---
 
@@ -212,16 +213,16 @@ Step 4 → Deploy Testrigs (optional) (helmsman_testrigs.yml)   ~10 min
 
 | Field | Value to enter |
 |---|---|
-| `profile` | `esignet` |
+| `profile` | `esignet-standalone` |
 | `mode` | `apply` |
 | `domain_name` | your base domain — e.g. `sandbox.xyz.net` |
-| `db_port` *(MOSIP platform external postgres)* | leave blank — not used by the `esignet` profile |
+| `db_port` *(MOSIP platform external postgres)* | leave blank — not used by the `esignet-standalone` profile |
 | `esignet_db_port` *(esignet container postgres)* | `5432` |
 | `clusterid` | your Rancher cluster ID — e.g. `c-xxxxx` |
 | `env_name` | a short label for your environment — e.g. `sandbox` |
 | `slack_channel_name` | your Slack channel — e.g. `#mosip-alerts` |
 
-> **Note:** The form always shows both `db_port` and `esignet_db_port` fields regardless of profile — for `esignet`, fill in only `esignet_db_port` and leave `db_port` blank.
+> **Note:** The form always shows both `db_port` and `esignet_db_port` fields regardless of profile — for `esignet-standalone`, fill in only `esignet_db_port` and leave `db_port` blank.
 
 6. Click the green **`Run workflow`** button
 
@@ -249,14 +250,15 @@ All pods should show `Running` or `Completed`.
 
 | Field | Value to enter |
 |---|---|
-| `profile` | `esignet` |
+| `profile` | `esignet-standalone` |
 | `mode` | `apply` |
 | `skip_mosip_dsf_check` | **tick this** — standalone has no MOSIP deployment to wait for |
 | `delete_existing_jobs` | tick only if re-running after a failure; leave unticked on first deploy |
 | `domain_name` | your base domain — e.g. `sandbox.xyz.net` |
 | `esignet_db_port` | `5432` |
 | `mosipid1_domain_name` | MOSIP-ID1 base domain — e.g. `mosipid1.xyz.net` *(leave blank if not using MOSIP-ID1)* |
-| `mosipid2_domain_name` | MOSIP-ID2 base domain — e.g. `mosipid2.xyz.net` *(leave blank if not using MOSIP-ID2)* |
+| `enable_mosipid2` | toggle `true` to deploy the MOSIP-ID2 eSignet instance; leave `false` to skip it |
+| `mosipid2_domain_name` | MOSIP-ID2 base domain — e.g. `mosipid2.xyz.net` *(only required if `enable_mosipid2` is true)* |
 | `env_name` | your environment name — e.g. `sandbox` |
 
 > **Important:** Always tick `skip_mosip_dsf_check` for standalone eSignet — without it, the workflow waits for a `mosip-dsf=completed` namespace label that will never appear (there is no full MOSIP deployment in this mode), and the workflow will fail.
@@ -267,7 +269,9 @@ All pods should show `Running` or `Completed`.
 
 **How to know it succeeded:**
 ```bash
-kubectl get pods -n esignet-mock && kubectl get pods -n esignet-mosipid1 && kubectl get pods -n esignet-mosipid2 && kubectl get pods -n esignet-sunbird
+kubectl get pods -n esignet-mock && kubectl get pods -n esignet-mosipid1 && kubectl get pods -n esignet-sunbird
+# If enable_mosipid2 was set to true:
+kubectl get pods -n esignet-mosipid2
 ```
 All pods should show `Running`.
 

--- a/docs/HELMSMAN_EXTERNAL_GUIDE.md
+++ b/docs/HELMSMAN_EXTERNAL_GUIDE.md
@@ -13,7 +13,7 @@ The `helmsman_external.yml` workflow runs **two DSFs in parallel**:
 
 **Time required:** 20–40 minutes
 
-**Auto-trigger:** On successful completion, this workflow automatically triggers `helmsman_mosip.yml` — but only for MOSIP platform profiles. For the `esignet` profile, MOSIP is not triggered.
+**Auto-trigger:** On successful completion, this workflow automatically triggers `helmsman_mosip.yml` — but only for MOSIP platform profiles. For the `esignet-standalone` profile, MOSIP is not triggered.
 
 ---
 
@@ -23,7 +23,7 @@ Choose the profile that matches your deployment target:
 
 | Profile | Use when |
 |---------|----------|
-| `esignet` | eSignet standalone — 4 parallel instances (esignet, esignet-mosipid1, esignet-mosipid2, esignet-sunbird). No full MOSIP stack. |
+| `esignet-standalone` | eSignet standalone — up to 4 parallel instances (esignet-mock, esignet-mosipid1, esignet-mosipid2, esignet-sunbird). mosipid2 is optional via `enable_mosipid2` toggle. No full MOSIP stack. |
 | `mosip-platform-1.2.0.x` | Full MOSIP platform with Java 11 |
 | `mosip-platform-1.2.1.x` | Full MOSIP platform with Java 21 |
 
@@ -43,7 +43,7 @@ All secrets are **Environment Secrets** — configure at **Repository → Settin
 | `CLUSTER_WIREGUARD_WG0` | WireGuard VPN config for cluster access |
 | `SLACK_WEBHOOK_URL` | Slack incoming webhook URL (optional — for alerting) |
 
-### eSignet profile only
+### eSignet standalone profile only
 
 | Secret | Description |
 |--------|-------------|
@@ -70,7 +70,7 @@ reCAPTCHA v2 keys for each MOSIP service domain — add as **Environment Secrets
 
 | Input | Description | Example |
 |-------|-------------|---------|
-| `profile` | Deployment profile | `esignet` / `mosip-platform-1.2.0.x` / `mosip-platform-1.2.1.x` |
+| `profile` | Deployment profile | `esignet-standalone` / `mosip-platform-1.2.0.x` / `mosip-platform-1.2.1.x` |
 | `mode` | Helmsman mode | Always `apply` — dry-run will fail |
 | `domain_name` | Base domain for this environment | `soil38.mosip.net` |
 | `env_name` | Environment name | `soil38` |
@@ -91,11 +91,11 @@ reCAPTCHA v2 keys for each MOSIP service domain — add as **Environment Secrets
   > Can't find it? Search for "External" in the workflows list.
 - **(2)** Click the **Run workflow** dropdown button (top right) — this opens the form shown above.
 - **(3)** **Branch** — pick the branch you're deploying from (e.g., `MOSIP-44613`).
-- **(4)** **Deployment profile to use** — pick the profile you want (e.g., `mosip-platform-1.2.0.x` for full MOSIP, or `esignet` for eSignet standalone).
+- **(4)** **Deployment profile to use** — pick the profile you want (e.g., `mosip-platform-1.2.0.x` for full MOSIP, or `esignet-standalone` for eSignet standalone).
 - **(5)** **Choose Helmsman mode: dry-run or apply** — always pick **`apply`**. (`dry-run` is not a safe preview here — it will fail because required resources don't exist yet.)
 - **(6)** **Domain name for this environment** — type the web domain this environment should use (e.g., `example.xyz.net`).
 - **(7)** **PostgreSQL port for MOSIP platform external postgres** — only fill this in if you picked a `mosip-platform-*` profile in step 4. Type `5433` (or whatever port your external PostgreSQL uses).
-- **(8)** **PostgreSQL port for esignet standalone container postgres** — only fill this in if you picked the `esignet` profile in step 4. Type `5432`.
+- **(8)** **PostgreSQL port for esignet standalone container postgres** — only fill this in if you picked the `esignet-standalone` profile in step 4. Type `5432`.
 - **(9)** **Environment name** — a short nickname for this environment (e.g., `sandbox`, `dev`, `staging`).
 - **(10)** **Slack channel name for alerting** (optional) — the Slack channel that should receive alerts (e.g., `#mosip-alerts`). Leave blank if you don't want Slack alerts.
 - **(11)** **Slack webhook URL for alerting** (optional) — leave this blank; it's normally already saved as the `SLACK_WEBHOOK_URL` secret in your GitHub environment.

--- a/docs/HELMSMAN_MOSIP_GUIDE.md
+++ b/docs/HELMSMAN_MOSIP_GUIDE.md
@@ -8,7 +8,7 @@ Deploy the full MOSIP core services stack (22 namespaces, 50+ microservices) aft
 **DSF:** `Helmsman/dsf/<profile>/mosip-dsf.yaml`  
 **Profiles:** `mosip-platform-1.2.0.x` (Java 11) and `mosip-platform-1.2.1.x` (Java 21)
 
-> This workflow is **not used** for the `esignet` standalone profile — eSignet standalone does not deploy the full MOSIP stack.
+> This workflow is **not used** for the `esignet-standalone` profile — eSignet standalone does not deploy the full MOSIP stack.
 
 **Time required:** 30–60 minutes
 

--- a/docs/HELMSMAN_TESTRIGS_GUIDE.md
+++ b/docs/HELMSMAN_TESTRIGS_GUIDE.md
@@ -14,11 +14,11 @@ Deploy API, UI, and DSL test rigs after all services are running and partner onb
 
 | Profile | What deploys | Namespaces |
 |---------|-------------|------------|
-| `esignet` | `esignet-apitestrig` into 4 namespaces; optional signup apitestrig + uitestrig | `esignet`, `esignet-mosipid1`, `esignet-mosipid2`, `esignet-sunbird`, `signup` |
+| `esignet-standalone` | `esignet-apitestrig` into up to 4 namespaces; optional signup apitestrig + uitestrig | `esignet-mock`, `esignet-mosipid1`, `esignet-mosipid2` *(if enabled)*, `esignet-sunbird`, `signup` |
 | `mosip-platform-1.2.0.x` | API testrig, UI testrig, DSL testrig | MOSIP testrig namespaces |
 | `mosip-platform-1.2.1.x` | Same as above | MOSIP testrig namespaces |
 
-> **eSignet standalone (`esignet` profile):** Requires two additional workflow inputs — `mosipid1_domain_name` and `mosipid2_domain_name` — for the MOSIP-ID1 and MOSIP-ID2 apitestrig endpoints. The workflow validates these are provided before running.
+> **eSignet standalone (`esignet-standalone` profile):** Requires `mosipid1_domain_name` for the MOSIP-ID1 apitestrig endpoint. `mosipid2_domain_name` is only required if mosipid2 was enabled during eSignet deployment (`enable_mosipid2: true`).
 
 ---
 
@@ -62,7 +62,7 @@ No additional secrets required — MinIO root password is read automatically fro
 
 | Input | Description | Example |
 |-------|-------------|---------|
-| `profile` | Deployment profile | `esignet` / `mosip-platform-1.2.0.x` / `mosip-platform-1.2.1.x` |
+| `profile` | Deployment profile | `esignet-standalone` / `mosip-platform-1.2.0.x` / `mosip-platform-1.2.1.x` |
 | `mode` | Helmsman mode | Always `apply` — dry-run will fail |
 | `domain_name` | Base domain for this environment | `soil38.mosip.net` |
 | `db_port` | External postgres port — MOSIP platform only | `5433` |
@@ -75,7 +75,7 @@ No additional secrets required — MinIO root password is read automatically fro
 | Input | Description | Example |
 |-------|-------------|---------|
 | `mosipid1_domain_name` | Domain for the MOSIP-ID1 eSignet instance | `mosipid1.mosip.net` |
-| `mosipid2_domain_name` | Domain for the MOSIP-ID2 eSignet instance | `mosipid2.mosip.net` |
+| `mosipid2_domain_name` | Domain for the MOSIP-ID2 eSignet instance — only required if mosipid2 was enabled (`enable_mosipid2: true`) during eSignet deployment | `mosipid2.mosip.net` |
 
 > If not provided as inputs, values fall back to GitHub Environment Variables: `vars.MOSIPID1_DOMAIN_NAME` and `vars.MOSIPID2_DOMAIN_NAME`.
 
@@ -89,19 +89,19 @@ No additional secrets required — MinIO root password is read automatically fro
   > Can't find it? Search for "Testrig" or "Testrigs" in the workflows list.
 - **(2)** Click the **Run workflow** dropdown button (top right) — this opens the form shown above.
 - **(3)** **Branch** — pick the branch you're deploying from (e.g., `MOSIP-44613`).
-- **(4)** **Deployment profile to use** — pick the profile you want (e.g., `mosip-platform-1.2.0.x` or `esignet`).
+- **(4)** **Deployment profile to use** — pick the profile you want (e.g., `mosip-platform-1.2.0.x` or `esignet-standalone`).
 - **(5)** **Choose Helmsman mode: dry-run or apply** — always pick **`apply`**.
 - **(6)** **Domain name for this environment** — type the web domain this environment should use (e.g., `example.xyz.net`).
 - **(7)** **MOSIP-ID1 domain name** *(eSignet profile only)* — type the base domain used by the MOSIP-ID1 eSignet instance (e.g., `mosipid1.xyz.net`). Leave blank for MOSIP platform profiles.
 - **(8)** **QA base domain name** *(eSignet profile only)* — type the base domain used by the MOSIP-ID2 eSignet instance (e.g., `mosipid2.xyz.net`). Leave blank for MOSIP platform profiles.
 - **(9)** **PostgreSQL port for MOSIP platform external postgres** — only fill this in if you picked a `mosip-platform-*` profile in step 4. Type `5433` (or whatever port your external PostgreSQL uses).
-- **(10)** **PostgreSQL port for esignet standalone container postgres** — only fill this in if you picked the `esignet` profile in step 4. Type `5432`.
+- **(10)** **PostgreSQL port for esignet standalone container postgres** — only fill this in if you picked the `esignet-standalone` profile in step 4. Type `5432`.
 - **(11)** **Environment name** — a short nickname for this environment (e.g., `sandbox`, `dev`, `staging`).
 - **(12)** **Slack channel name for alerting** (optional) — the Slack channel that should receive test result notifications (e.g., `#mosip-alerts`). Leave blank if you don't want Slack alerts.
 - **(13)** **Slack webhook URL for alerting** (optional) — leave this blank; it's normally already saved as the `SLACK_WEBHOOK_URL` secret in your GitHub environment.
 - **(14)** Click the green **Run workflow** button to start the deployment.
 
-> **Note:** Steps 7–10 all appear in the form regardless of which profile you picked — fill in only the ones that match your profile (MOSIP-ID1/MOSIP-ID2 domains for `esignet`, PostgreSQL port for `mosip-platform-*`) and leave the rest blank.
+> **Note:** Steps 7–10 all appear in the form regardless of which profile you picked — fill in only the ones that match your profile (MOSIP-ID1/MOSIP-ID2 domains for `esignet-standalone`, PostgreSQL port for `mosip-platform-*`) and leave the rest blank.
 
 > **Important:** Always pass `--keep-untracked-releases` — without it Helmsman will delete releases from previous DSFs (esignet, oidc-ui, etc.) that aren't listed in `testrigs-dsf.yaml`. The workflow handles this automatically.
 

--- a/docs/SECRET_GENERATION_GUIDE.md
+++ b/docs/SECRET_GENERATION_GUIDE.md
@@ -287,7 +287,7 @@ A Fine-grained Personal Access Token (PAT) that allows GitHub Actions workflows 
 
 `GH_INFRA_PAT` is used in two places inside `helmsman_esignet.yml`:
 
-1. **Auto-trigger `helmsman_signup.yml`** — after a successful eSignet standalone deployment (`profile=esignet`), the `workflow-caller` job calls the GitHub Actions API to dispatch the signup workflow automatically. This requires `Actions: Read and write` on the PAT. Without it, the signup workflow will never be triggered even if eSignet deploys successfully.
+1. **Auto-trigger `helmsman_signup.yml`** — after a successful eSignet standalone deployment (`profile=esignet-standalone`), the `workflow-caller` job calls the GitHub Actions API to dispatch the signup workflow automatically. This requires `Actions: Read and write` on the PAT. Without it, the signup workflow will never be triggered even if eSignet deploys successfully.
 2. **Repository operations during deploy** — used as `GH_TOKEN` override for authenticated GitHub API calls within the deploy job.
 
 ### How to Generate GH_INFRA_PAT

--- a/docs/WORKFLOW_GUIDE.md
+++ b/docs/WORKFLOW_GUIDE.md
@@ -162,7 +162,7 @@ If Terraform Apply = ☐ (unchecked)
  | **Use workflow from** | `Branch: release-0.1.0` | Your branch | Dropdown at top |
  | **Cloud Provider** | `aws` | `aws` | Where to deploy |
  | **Component** | `infra` | `infra` | Main MOSIP infrastructure |
- | **Profile** | `esignet` or `mosip` | `esignet` | Selects tfvars and cluster size — see below |
+ | **Profile** | `esignet-standalone` or `mosip` | `esignet` | Selects tfvars and cluster size — see below |
  | **Backend** | `local` or `s3` | `local` | State storage location |
  | **Terraform apply** | ✅ | ✅ | Check to deploy, uncheck for dry run |
 
@@ -246,7 +246,7 @@ If Terraform Apply = ☐ (unchecked)
 
 ### Deployment Flow
 
-**eSignet standalone profile** (`profile=esignet`):
+**eSignet standalone profile** (`profile=esignet-standalone`):
 ```
 External (prereq + external-dsf, parallel) → eSignet (4 parallel instances) → Testrigs
 ```
@@ -310,7 +310,7 @@ Mode: apply ✅
  | Parameter | What to Select | Notes |
  |-----------|---------------|-------|
  | **Branch** | Your deployment branch | Selects the GitHub Environment for secrets/vars |
- | **profile** | `esignet` / `mosip-platform-1.2.0.x` / `mosip-platform-1.2.1.x` | Selects DSF subdirectory |
+ | **profile** | `esignet-standalone` / `mosip-platform-1.2.0.x` / `mosip-platform-1.2.1.x` | Selects DSF subdirectory |
  | **mode** | `apply` | MUST be apply, not dry-run! |
  | **domain_name** | `sandbox.example.net` | Your deployment domain (or set `vars.DOMAIN_NAME`) |
  | **db_port** | `5433` | MOSIP platform external postgres port (or `vars.DB_PORT`) |
@@ -332,7 +332,7 @@ Mode: apply ✅
  ```
  ✅ On success → Automatically triggers MOSIP Services deployment (for MOSIP platform profiles)
  ```
- > For `profile=esignet`, the MOSIP auto-trigger is skipped — run the eSignet workflow directly next.
+ > For `profile=esignet-standalone`, the MOSIP auto-trigger is skipped — run the eSignet workflow directly next.
 
 ---
 
@@ -342,7 +342,7 @@ Mode: apply ✅
 
 **Workflow Name**: `Deploy MOSIP services using Helmsman`
 
-**Trigger**: Automatically runs after Workflow 1 succeeds (MOSIP platform profiles only — NOT triggered for `profile=esignet`)
+**Trigger**: Automatically runs after Workflow 1 succeeds (MOSIP platform profiles only — NOT triggered for `profile=esignet-standalone`)
 
 **Manual Run** (if needed):
 
@@ -383,16 +383,17 @@ Mode: apply ✅
  | Parameter | What to Select | Notes |
  |-----------|---------------|-------|
  | **Branch** | Your deployment branch | |
- | **profile** | `esignet` / `mosip-platform-1.2.0.x` / `mosip-platform-1.2.1.x` | Must match what you used for external-dsf |
+ | **profile** | `esignet-standalone` / `mosip-platform-1.2.0.x` / `mosip-platform-1.2.1.x` | Must match what you used for external-dsf |
  | **mode** | `apply` | MUST be apply! |
  | **domain_name** | `sandbox.example.net` | Or set `vars.DOMAIN_NAME` |
  | **esignet_db_port** | `5432` (esignet) / `5433` (MOSIP platform) | Or set `vars.ESIGNET_DB_PORT` |
- | **mosipid1_domain_name** | `mosipid1.example.net` | esignet profile only — MOSIP-ID1 environment domain |
- | **mosipid2_domain_name** | `mosipid2.example.net` | esignet profile only — MOSIP-ID2 environment domain |
+ | **mosipid1_domain_name** | `mosipid1.example.net` | esignet-standalone profile only — MOSIP-ID1 environment domain |
+ | **enable_mosipid2** | `false` (default) / `true` | Toggle to deploy MOSIP-ID2 instance; leave `false` to skip |
+ | **mosipid2_domain_name** | `mosipid2.example.net` | Required only if `enable_mosipid2` is `true` |
  | **skip_mosip_dsf_check** | `true` for standalone, `false` when MOSIP is deployed | |
  | **delete_existing_jobs** | `true` when re-running after a failed attempt | Cleans up stale onboarder jobs |
 
-3. **Monitor Progress** (25-35 minutes for esignet profile with 4 instances)
+3. **Monitor Progress** (25-35 minutes for esignet-standalone profile with up to 4 instances)
  ```
  → SoftHSM (all 4 namespaces)
  → Config server
@@ -444,8 +445,8 @@ kubectl get pods -n esignet-sunbird # esignet profile only
  | **profile** | Same as your deployment profile | |
  | **mode** | `apply` | |
  | **domain_name** | `sandbox.example.net` | Or `vars.DOMAIN_NAME` |
- | **mosipid1_domain_name** | `mosipid1.example.net` | esignet profile only |
- | **mosipid2_domain_name** | `mosipid2.example.net` | esignet profile only |
+ | **mosipid1_domain_name** | `mosipid1.example.net` | esignet-standalone profile only |
+ | **mosipid2_domain_name** | `mosipid2.example.net` | esignet-standalone only — required if mosipid2 was enabled |
  | **db_port** | `5433` | MOSIP platform only |
  | **esignet_db_port** | `5432` | eSignet profile |
 
@@ -523,10 +524,10 @@ Profile: [esignet | mosip]
 
 | Profile | tfvars file | Cluster size | Use for |
 |---------|------------|--------------|---------|
-| `esignet` | `profiles/esignet/aws.tfvars` | 4-node K8s cluster | eSignet standalone deployment |
-| `mosip` | `profiles/mosip/aws.tfvars` | 7-node K8s cluster | Full MOSIP platform deployment |
+| `esignet-standalone` | `profiles/esignet-standalone/aws.tfvars` | eSignet standalone deployment |
+| `mosip` | `profiles/mosip/aws.tfvars` | Full MOSIP platform deployment |
 
-**Important**: The Terraform profile (`esignet` / `mosip`) and the Helmsman profile (`esignet` / `mosip-platform-1.2.0.x` / `mosip-platform-1.2.1.x`) are separate inputs. After running `infra` with `profile=mosip`, you choose the specific MOSIP platform version when running the Helmsman workflows.
+**Important**: The Terraform profile (`esignet-standalone` / `mosip`) and the Helmsman profile (`esignet-standalone` / `mosip-platform-1.2.0.x` / `mosip-platform-1.2.1.x`) are separate inputs. After running `infra` with `profile=mosip`, you choose the specific MOSIP platform version when running the Helmsman workflows.
 
 ---
 
@@ -754,7 +755,7 @@ Updating existing deployment → ☐ Uncheck first to see changes
 
 ## Visual Workflow Summary
 
-### eSignet Standalone (`profile=esignet`)
+### eSignet Standalone (`profile=esignet-standalone`)
 
 ```
 DEPLOYMENT FLOW:
@@ -766,14 +767,14 @@ DEPLOYMENT FLOW:
  └── RKE2 Kubernetes cluster
  └── PAUSE: Add KUBECONFIG secret
 
-3. Helmsman: External Dependencies  [helmsman_external.yml, profile=esignet]
+3. Helmsman: External Dependencies  [helmsman_external.yml, profile=esignet-standalone]
  └── prereq-dsf + external-dsf (parallel)
  └── PostgreSQL, Redis, Kafka, SoftHSM, Keycloak, Captcha, MinIO
 
-4. Helmsman: eSignet  [helmsman_esignet.yml, profile=esignet]
- └── 4 parallel instances (esignet / esignet-mosipid1 / esignet-mosipid2 / esignet-sunbird)
+4. Helmsman: eSignet  [helmsman_esignet.yml, profile=esignet-standalone]
+ └── 3 instances always (esignet-mock / esignet-mosipid1 / esignet-sunbird) + esignet-mosipid2 if enable_mosipid2=true
 
-5. Helmsman: Test Rigs  [helmsman_testrigs.yml, profile=esignet, manual]
+5. Helmsman: Test Rigs  [helmsman_testrigs.yml, profile=esignet-standalone, manual]
  └── API testrigs for all 4 esignet namespaces
  └── ✅ Deployment Complete!
 ```

--- a/docs/esignet_README.md
+++ b/docs/esignet_README.md
@@ -227,16 +227,17 @@ Custom Helm values are stored in:
 - **(1)** Go to **Actions** (top of the repository page) → click **"Deploy eSignet using Helmsman"** in the list on the left.
 - **(2)** Click the **Run workflow** dropdown button (top right) — this opens the form shown above.
 - **(3)** **Branch** — pick the branch you're deploying from (e.g., `MOSIP-44613`).
-- **(4)** **Deployment profile to use** — pick the profile you want (e.g., `mosip-platform-1.2.0.x`, or `esignet` for standalone).
+- **(4)** **Deployment profile to use** — pick the profile you want (e.g., `mosip-platform-1.2.0.x`, or `esignet-standalone` for standalone).
 - **(5)** **Choose Helmsman mode: dry-run or apply** — always pick **`apply`**.
 - **(6)** **Skip MOSIP DSF completion check** (checkbox) — for eSignet standalone deployments, tick this. For MOSIP platform profiles, leave it unticked (default) so the workflow waits for MOSIP to finish first.
 - **(7)** **Delete existing onboarder jobs before deploy** (checkbox) — only tick this when re-running after a failure. Leave unticked on a first-time deploy.
 - **(8)** **Domain name for this environment** — type the web domain this environment should use (e.g., `example.xyz.net`).
 - **(9)** **PostgreSQL port for esignet databases** — type `5432` for eSignet standalone, or `5433` if this is part of a MOSIP platform profile.
 - **(10)** **MOSIP-ID1 domain name** *(eSignet standalone only)* — base domain for the MOSIP-ID1 eSignet instance (e.g., `mosipid1.xyz.net`). Leave blank if you're not deploying MOSIP-ID1.
-- **(11)** **MOSIP-ID2 domain name** *(eSignet standalone only)* — base domain for the MOSIP-ID2 eSignet instance (e.g., `mosipid2.xyz.net`). Leave blank if you're not deploying MOSIP-ID2.
-- **(12)** **Environment name** — a short nickname for this environment (e.g., `sandbox`, `dev`, `staging`).
-- **(13)** Click the green **Run workflow** button to start the deployment.
+- **(11)** **Enable MOSIP-ID2 eSignet instance** *(eSignet standalone only)* — toggle to `true` to deploy the MOSIP-ID2 instance (softhsm, esignet, oidc-ui, mock-rp). Leave `false` to skip it entirely.
+- **(12)** **MOSIP-ID2 domain name** *(eSignet standalone only, required if enable_mosipid2 is true)* — base domain for the MOSIP-ID2 eSignet instance (e.g., `mosipid2.xyz.net`).
+- **(13)** **Environment name** — a short nickname for this environment (e.g., `sandbox`, `dev`, `staging`).
+- **(14)** Click the green **Run workflow** button to start the deployment.
 
 ---
 
@@ -253,13 +254,14 @@ Custom Helm values are stored in:
 
 | Input | Description | Required | Notes |
 |-------|-------------|----------|-------|
-| `profile` | Deployment profile | Yes | `mosip-platform-1.2.0.x`, `mosip-platform-1.2.1.x`, or `esignet` (standalone) |
+| `profile` | Deployment profile | Yes | `mosip-platform-1.2.0.x`, `mosip-platform-1.2.1.x`, or `esignet-standalone` |
 | `mode` | `dry-run` or `apply` | Yes | Always use `apply` — dry-run will fail |
 | `domain_name` | Your base domain | Yes | Or set `vars.DOMAIN_NAME` in GitHub Environment |
 | `esignet_db_port` | PostgreSQL port for esignet databases | Yes | `5433` for MOSIP platform external postgres, `5432` for eSignet standalone (or `vars.ESIGNET_DB_PORT`) |
-| `env_name` | Environment name shown on the landing page | Yes | Or set `vars.ENV_NAME` in GitHub Environment |
 | `mosipid1_domain_name` | Base domain for the MOSIP-ID1 eSignet instance | No | eSignet standalone only — leave blank otherwise (or `vars.MOSIPID1_DOMAIN_NAME`) |
-| `mosipid2_domain_name` | Base domain for the MOSIP-ID2 eSignet instance | No | eSignet standalone only — leave blank otherwise (or `vars.MOSIPID2_DOMAIN_NAME`) |
+| `enable_mosipid2` | Deploy MOSIP-ID2 eSignet instance | No | Toggle `true` to deploy softhsm, esignet, oidc-ui, mock-rp for mosipid2; default `false` |
+| `mosipid2_domain_name` | Base domain for the MOSIP-ID2 eSignet instance | No | Required only if `enable_mosipid2` is `true` (or `vars.MOSIPID2_DOMAIN_NAME`) |
+| `env_name` | Environment name shown on the landing page | Yes | Or set `vars.ENV_NAME` in GitHub Environment |
 | `skip_mosip_dsf_check` | Skip MOSIP DSF completion check | No | Tick for eSignet standalone deploys; default `false` otherwise |
 | `delete_existing_jobs` | Delete stale onboarder jobs before deploy | No | Set `true` when re-running after a failure |
 


### PR DESCRIPTION
## Summary

- Renames profile identifier `esignet` → `esignet-standalone` consistently across all documentation files to match the actual DSF directory and workflow input value
- Adds `enable_mosipid2` workflow input to tables and step-by-step guides — mosipid2 is now an optional runtime toggle, not a DSF file edit
- Marks `mosipid2_domain_name` as required only when `enable_mosipid2` is `true`
- Corrects eSignet instance count: 3 instances always deployed (esignet-mock, esignet-mosipid1, esignet-sunbird) + esignet-mosipid2 conditionally
- Reorders `enable_mosipid2` before `mosipid2_domain_name` in input descriptions to match workflow UI order

## Files changed

- `docs/DSF_CONFIGURATION_GUIDE.md`
- `docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md`
- `docs/HELMSMAN_EXTERNAL_GUIDE.md`
- `docs/HELMSMAN_MOSIP_GUIDE.md`
- `docs/HELMSMAN_TESTRIGS_GUIDE.md`
- `docs/SECRET_GENERATION_GUIDE.md`
- `docs/WORKFLOW_GUIDE.md`
- `docs/esignet_README.md`

## Test plan

- [ ] Verify all docs use `esignet-standalone` as the profile name
- [ ] Verify `enable_mosipid2` appears before `mosipid2_domain_name` in input tables
- [ ] Verify `mosipid2_domain_name` is marked conditional on `enable_mosipid2`

Closes #1888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clarified the standalone deployment flow with a new infrastructure provisioning step and updated workflow inputs.
  * Added support for optionally enabling MOSIP-ID2 during deployment.

* **Bug Fixes**
  * Improved handling of shared configuration so deployment copies the generated settings directly between namespaces more reliably.

* **Documentation**
  * Updated deployment, workflow, and configuration guides to use the `esignet-standalone` profile and reflect the latest setup and run instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->