### PR TITLE
Fixes: mosip/mosip-infra#1915 Auto-publish KUBECONFIG from Rancher after infra apply

### DIFF
--- a/.github/scripts/rancher-fetch-kubeconfig.sh
+++ b/.github/scripts/rancher-fetch-kubeconfig.sh
@@ -79,8 +79,10 @@ command -v jq   >/dev/null 2>&1 || die "jq is required"
 RANCHER_URL="${RANCHER_URL%/}"
 [[ "$RANCHER_URL" =~ ^https:// ]] \
   || die "RANCHER_URL must begin with https:// (got: $RANCHER_URL)"
-[[ -n "$CLUSTER_NAME" ]] && [[ "$CLUSTER_NAME" =~ ^[a-zA-Z0-9._-]+$ ]] \
-  || die "CLUSTER_NAME must contain only [a-zA-Z0-9._-] (got: $CLUSTER_NAME)"
+if [[ -n "$CLUSTER_NAME" ]]; then
+  [[ "$CLUSTER_NAME" =~ ^[a-zA-Z0-9._-]+$ ]] \
+    || die "CLUSTER_NAME must contain only [a-zA-Z0-9._-] (got: $CLUSTER_NAME)"
+fi
 [[ "$MAX_ATTEMPTS" =~ ^[0-9]+$ && "$MAX_ATTEMPTS" -gt 0 ]] \
   || die "MAX_ATTEMPTS must be a positive integer (got: $MAX_ATTEMPTS)"
 [[ "$SLEEP_SECONDS" =~ ^[0-9]+$ && "$SLEEP_SECONDS" -gt 0 ]] \
@@ -123,8 +125,9 @@ api() {
 
 fetch_cluster_id_by_name() {
   local json count id
-  json="$(api GET "/v3/clusters?name=$(urlencode "$CLUSTER_NAME")" || true)"
-  [[ -n "$json" ]] || return 1
+  if ! json="$(api GET "/v3/clusters?name=$(urlencode "$CLUSTER_NAME")")"; then
+    die "Failed to query Rancher clusters by name"
+  fi
   count="$(jq -r --arg name "$CLUSTER_NAME" '[.data[]? | select(.name == $name)] | length' <<<"$json")"
   if (( count > 1 )); then
     die "Multiple Rancher clusters named '$CLUSTER_NAME'; resolve duplicates manually"
@@ -136,8 +139,9 @@ fetch_cluster_id_by_name() {
 
 cluster_is_active() {
   local json state
-  json="$(api GET "/v3/clusters/$(urlencode "$CLUSTER_ID")" || true)"
-  [[ -n "$json" ]] || return 1
+  if ! json="$(api GET "/v3/clusters/$(urlencode "$CLUSTER_ID")")"; then
+    die "Failed to query Rancher cluster '$CLUSTER_ID'"
+  fi
   state="$(jq -r '.state // empty' <<<"$json")"
   [[ "$state" == "active" ]]
 }
@@ -173,8 +177,9 @@ validate_kubeconfig_yaml() {
 
 if [[ -z "$CLUSTER_ID" ]]; then
   log "Looking up cluster '${CLUSTER_NAME}' in Rancher ..."
-  CLUSTER_ID="$(fetch_cluster_id_by_name || true)"
-  [[ -n "$CLUSTER_ID" ]] || die "Cluster '$CLUSTER_NAME' not found in Rancher"
+  if ! CLUSTER_ID="$(fetch_cluster_id_by_name)"; then
+    die "Cluster '$CLUSTER_NAME' not found in Rancher"
+  fi
 fi
 log "Using Rancher cluster id=${CLUSTER_ID}"
 

--- a/.github/scripts/rancher-fetch-kubeconfig.sh
+++ b/.github/scripts/rancher-fetch-kubeconfig.sh
@@ -137,6 +137,23 @@ fetch_cluster_id_by_name() {
   printf '%s' "$id"
 }
 
+cluster_status_summary() {
+  local json
+  if ! json="$(api GET "/v3/clusters/$(urlencode "$CLUSTER_ID")")"; then
+    err "Could not fetch cluster status for ${CLUSTER_ID}"
+    return 1
+  fi
+  jq '{
+    id,
+    name,
+    state,
+    transitioning,
+    transition: (.transitioningMessage // .transition // empty),
+    agentImage: (.agentImage // empty),
+    driver: (.driver // empty)
+  }' <<<"$json" >&2
+}
+
 cluster_is_active() {
   local json state
   if ! json="$(api GET "/v3/clusters/$(urlencode "$CLUSTER_ID")")"; then
@@ -146,17 +163,30 @@ cluster_is_active() {
   [[ "$state" == "active" ]]
 }
 
+cluster_current_state() {
+  local json
+  if ! json="$(api GET "/v3/clusters/$(urlencode "$CLUSTER_ID")")"; then
+    printf 'unknown'
+    return 1
+  fi
+  jq -r '.state // "unknown"' <<<"$json"
+}
+
 wait_for_cluster_active() {
-  local attempt
+  local attempt state
   for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
     if cluster_is_active; then
       log "Cluster ${CLUSTER_ID} is active"
       return 0
     fi
-    log "Waiting for cluster ${CLUSTER_ID} to become active (attempt ${attempt}/${MAX_ATTEMPTS}) ..."
+    state="$(cluster_current_state || true)"
+    log "Waiting for cluster ${CLUSTER_ID} to become active (state=${state:-unknown}, attempt ${attempt}/${MAX_ATTEMPTS}) ..."
     sleep "$SLEEP_SECONDS"
   done
-  die "Cluster ${CLUSTER_ID} did not become active within $((MAX_ATTEMPTS * SLEEP_SECONDS)) seconds"
+  err "Cluster ${CLUSTER_ID} did not become active within $((MAX_ATTEMPTS * SLEEP_SECONDS)) seconds"
+  err "Current cluster status:"
+  cluster_status_summary || true
+  die "Import may not have completed on the downstream cluster. Check: Terraform apply logs (Ansible rancher import), cattle-system namespace on the control plane, and Rancher UI → Cluster Management (include pending clusters)."
 }
 
 generate_kubeconfig_yaml() {

--- a/.github/scripts/rancher-fetch-kubeconfig.sh
+++ b/.github/scripts/rancher-fetch-kubeconfig.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# rancher-fetch-kubeconfig.sh - Fetch a cluster kubeconfig from Rancher via API.
+#
+# Replaces the manual Rancher UI step: Cluster → Kubeconfig File → Copy/Download.
+# Uses the same scoped API token as rancher-register-cluster.sh.
+#
+# Requires: bash 4+, curl, jq.
+
+set -euo pipefail
+
+RANCHER_URL="${RANCHER_URL:-}"
+RANCHER_TOKEN="${RANCHER_TOKEN:-}"
+CLUSTER_NAME="${CLUSTER_NAME:-}"
+CLUSTER_ID="${CLUSTER_ID:-}"
+INSECURE="${INSECURE:-false}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-60}"
+SLEEP_SECONDS="${SLEEP_SECONDS:-5}"
+
+usage() {
+  cat <<'EOF'
+Usage: rancher-fetch-kubeconfig.sh --rancher-url <url> --token <token> [--cluster-name <name> | --cluster-id <id>] [--insecure]
+
+Required:
+  --rancher-url <url>     Rancher base URL (https://rancher.<env>.mosip.net, NO /v3)
+  --token <token>         Rancher API bearer token
+
+Cluster selector (one required):
+  --cluster-name <name>   Rancher cluster name ([a-zA-Z0-9._-]+)
+  --cluster-id <id>       Rancher cluster id (e.g. c-m-xxxxx)
+
+Optional:
+  --insecure              Skip TLS verification for Rancher API calls only
+  -h, --help              Show help
+
+Environment (optional):
+  MAX_ATTEMPTS            Wait attempts for cluster to become active (default: 60)
+  SLEEP_SECONDS           Seconds between wait attempts (default: 5)
+
+Output (stdout): raw kubeconfig YAML (for GitHub KUBECONFIG environment secret).
+Logs go to stderr.
+
+Note: Run after infra deploy + Rancher import. The cluster must reach state "active".
+EOF
+}
+
+err() { echo "[rancher-kubeconfig][ERROR] $*" >&2; }
+die() { err "$*"; exit 1; }
+log() { echo "[rancher-kubeconfig] $*" >&2; }
+
+require_arg() {
+  local flag="$1"
+  [[ $# -ge 2 && -n "${2:-}" && "$2" != --* ]] || die "$flag requires a value"
+}
+
+urlencode() {
+  jq -rn --arg v "$1" '$v|@uri'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rancher-url)   require_arg --rancher-url "${2-}";   RANCHER_URL="$2"; shift 2 ;;
+    --token)         require_arg --token "${2-}";         RANCHER_TOKEN="$2"; shift 2 ;;
+    --cluster-name)  require_arg --cluster-name "${2-}";  CLUSTER_NAME="$2"; shift 2 ;;
+    --cluster-id)    require_arg --cluster-id "${2-}";    CLUSTER_ID="$2"; shift 2 ;;
+    --insecure)      INSECURE="true"; shift ;;
+    -h|--help)       usage; exit 0 ;;
+    *)               die "Unknown argument: $1 (use --help)" ;;
+  esac
+done
+
+[[ ${BASH_VERSINFO[0]} -ge 4 ]] || die "bash 4+ is required"
+[[ -n "$RANCHER_URL" ]]        || die "--rancher-url is required"
+[[ -n "$RANCHER_TOKEN" ]]       || die "--token is required"
+[[ -n "$CLUSTER_NAME" || -n "$CLUSTER_ID" ]] || die "--cluster-name or --cluster-id is required"
+command -v curl >/dev/null 2>&1 || die "curl is required"
+command -v jq   >/dev/null 2>&1 || die "jq is required"
+
+RANCHER_URL="${RANCHER_URL%/}"
+[[ "$RANCHER_URL" =~ ^https:// ]] \
+  || die "RANCHER_URL must begin with https:// (got: $RANCHER_URL)"
+[[ -n "$CLUSTER_NAME" ]] && [[ "$CLUSTER_NAME" =~ ^[a-zA-Z0-9._-]+$ ]] \
+  || die "CLUSTER_NAME must contain only [a-zA-Z0-9._-] (got: $CLUSTER_NAME)"
+[[ "$MAX_ATTEMPTS" =~ ^[0-9]+$ && "$MAX_ATTEMPTS" -gt 0 ]] \
+  || die "MAX_ATTEMPTS must be a positive integer (got: $MAX_ATTEMPTS)"
+[[ "$SLEEP_SECONDS" =~ ^[0-9]+$ && "$SLEEP_SECONDS" -gt 0 ]] \
+  || die "SLEEP_SECONDS must be a positive integer (got: $SLEEP_SECONDS)"
+
+api() {
+  local method="$1" path="$2" body="${3:-}"
+  local tmp status curl_args=()
+  tmp="$(mktemp "${TMPDIR:-/tmp}/rancher-api.XXXXXX")"
+  trap "rm -f $(printf %q "$tmp")" RETURN
+
+  curl_args=(
+    -sS
+    -o "$tmp"
+    -w "%{http_code}"
+    -X "$method"
+    -H "Authorization: Bearer ${RANCHER_TOKEN}"
+    -H "Content-Type: application/json"
+    -H "Accept: application/json"
+    --connect-timeout 10
+    --max-time 60
+  )
+  [[ "$INSECURE" == "true" ]] && curl_args+=(-k)
+  [[ -n "$body" ]] && curl_args+=(-d "$body")
+
+  if ! status="$(curl "${curl_args[@]}" "${RANCHER_URL}${path}")"; then
+    err "Rancher API ${method} ${path}: curl failed"
+    [[ -s "$tmp" ]] && cat "$tmp" >&2
+    return 1
+  fi
+
+  if [[ ! "$status" =~ ^[0-9]+$ ]] || (( status >= 400 )); then
+    err "Rancher API ${method} ${path} failed with HTTP ${status:-unknown}"
+    [[ -s "$tmp" ]] && cat "$tmp" >&2
+    return 1
+  fi
+
+  cat "$tmp"
+}
+
+fetch_cluster_id_by_name() {
+  local json count id
+  json="$(api GET "/v3/clusters?name=$(urlencode "$CLUSTER_NAME")" || true)"
+  [[ -n "$json" ]] || return 1
+  count="$(jq -r --arg name "$CLUSTER_NAME" '[.data[]? | select(.name == $name)] | length' <<<"$json")"
+  if (( count > 1 )); then
+    die "Multiple Rancher clusters named '$CLUSTER_NAME'; resolve duplicates manually"
+  fi
+  id="$(jq -r --arg name "$CLUSTER_NAME" '[.data[]? | select(.name == $name)][0].id // empty' <<<"$json")"
+  [[ -n "$id" ]] || return 1
+  printf '%s' "$id"
+}
+
+cluster_is_active() {
+  local json state
+  json="$(api GET "/v3/clusters/$(urlencode "$CLUSTER_ID")" || true)"
+  [[ -n "$json" ]] || return 1
+  state="$(jq -r '.state // empty' <<<"$json")"
+  [[ "$state" == "active" ]]
+}
+
+wait_for_cluster_active() {
+  local attempt
+  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+    if cluster_is_active; then
+      log "Cluster ${CLUSTER_ID} is active"
+      return 0
+    fi
+    log "Waiting for cluster ${CLUSTER_ID} to become active (attempt ${attempt}/${MAX_ATTEMPTS}) ..."
+    sleep "$SLEEP_SECONDS"
+  done
+  die "Cluster ${CLUSTER_ID} did not become active within $((MAX_ATTEMPTS * SLEEP_SECONDS)) seconds"
+}
+
+generate_kubeconfig_yaml() {
+  local response config
+  response="$(api POST "/v3/clusters/$(urlencode "$CLUSTER_ID")?action=generateKubeconfig" '{}')"
+  config="$(jq -r '.config // empty' <<<"$response")"
+  [[ -n "$config" && "$config" != "null" ]] || die "generateKubeconfig returned empty config"
+  printf '%s\n' "$config"
+}
+
+validate_kubeconfig_yaml() {
+  local cfg="$1"
+  grep -q '^apiVersion:' <<<"$cfg" || return 1
+  grep -q '^kind: Config' <<<"$cfg" || return 1
+  grep -q '^clusters:' <<<"$cfg" || return 1
+  return 0
+}
+
+if [[ -z "$CLUSTER_ID" ]]; then
+  log "Looking up cluster '${CLUSTER_NAME}' in Rancher ..."
+  CLUSTER_ID="$(fetch_cluster_id_by_name || true)"
+  [[ -n "$CLUSTER_ID" ]] || die "Cluster '$CLUSTER_NAME' not found in Rancher"
+fi
+log "Using Rancher cluster id=${CLUSTER_ID}"
+
+wait_for_cluster_active
+
+log "Generating kubeconfig via Rancher API ..."
+KUBECONFIG_YAML="$(generate_kubeconfig_yaml)"
+validate_kubeconfig_yaml "$KUBECONFIG_YAML" \
+  || die "Rancher returned data that does not look like a kubeconfig"
+
+log "Kubeconfig fetched successfully ($(wc -l <<<"$KUBECONFIG_YAML") lines)."
+printf '%s\n' "$KUBECONFIG_YAML"

--- a/.github/scripts/rancher-grant-cluster-access.sh
+++ b/.github/scripts/rancher-grant-cluster-access.sh
@@ -1,0 +1,584 @@
+#!/usr/bin/env bash
+#
+# rancher-grant-cluster-access.sh - Grant a Keycloak (or other IdP) group access to a Rancher cluster.
+#
+# When clusters are registered with a personal/service API token, only that principal
+# sees the cluster in Rancher UI. This script creates a clusterRoleTemplateBinding so
+# an IdP group (e.g. DEVOPS) receives cluster-owner (or another role) without manual UI steps.
+#
+# Groups can be bound before the downstream cluster finishes importing (pending state).
+#
+# Requires: bash 4+, curl, jq.
+
+set -euo pipefail
+
+RANCHER_URL="${RANCHER_URL:-}"
+RANCHER_TOKEN="${RANCHER_TOKEN:-}"
+CLUSTER_NAME="${CLUSTER_NAME:-}"
+CLUSTER_ID="${CLUSTER_ID:-}"
+GROUP_NAME="${GROUP_NAME:-}"
+GROUP_PRINCIPAL_ID="${GROUP_PRINCIPAL_ID:-}"
+GROUP_AUTH_PREFIX="${GROUP_AUTH_PREFIX:-}"
+ROLE_TEMPLATE_ID="${ROLE_TEMPLATE_ID:-cluster-owner}"
+BINDING_NAME="${BINDING_NAME:-}"
+INSECURE="${INSECURE:-false}"
+LIST_BINDINGS="${LIST_BINDINGS:-false}"
+FIX_MISBOUND_USER="${FIX_MISBOUND_USER:-false}"
+
+usage() {
+  cat <<'EOF'
+Usage: rancher-grant-cluster-access.sh --rancher-url <url> --token <token> \
+  [--cluster-name <name> | --cluster-id <id>] \
+  [--group <name> | --group-principal-id <id>] [options]
+
+Required:
+  --rancher-url <url>           Rancher base URL (https://rancher.<env>.mosip.net, NO /v3)
+  --token <token>               Rancher API bearer token (needs permission to manage cluster RBAC)
+
+Cluster selector (one required):
+  --cluster-name <name>         Rancher cluster name
+  --cluster-id <id>             Rancher cluster id (e.g. c-m-xxxxx)
+
+Group selector (one required unless GROUP_NAME / GROUP_PRINCIPAL_ID set):
+  --group <name>                IdP group name as shown in Rancher (e.g. DEVOPS)
+  --group-principal-id <id>     Full principal id (e.g. keycloak_group://DEVOPS)
+  --list-bindings               Print cluster role bindings and exit
+  --fix-misbound-user           Remove wrong DEVOPS bindings (user principal, triple-slash group id, etc.)
+
+Optional:
+  --role-template <id>          Rancher role template (default: cluster-owner)
+  --group-auth-prefix <prefix>  Principal prefix when building group id (default: auto-detect)
+  --binding-name <name>         Binding resource name (default: crtb-<group>-<role>)
+  --insecure                    Skip TLS verification for Rancher API calls only
+  -h, --help                    Show help
+
+Environment (optional):
+  GROUP_NAME, GROUP_PRINCIPAL_ID, GROUP_AUTH_PREFIX, ROLE_TEMPLATE_ID, BINDING_NAME
+
+Example:
+  rancher-grant-cluster-access.sh \
+    --rancher-url https://rancher.mosip.net \
+    --token "$RANCHER_TOKEN" \
+    --cluster-name dev1 \
+    --group DEVOPS \
+    --role-template cluster-owner \
+    --group-principal-id keycloak_group://DEVOPS \
+    --fix-misbound-user
+EOF
+}
+
+LAST_HTTP_STATUS=""
+DELETIONS_PERFORMED="false"
+REPAIRS_PERFORMED="false"
+
+err() { echo "[rancher-grant][ERROR] $*" >&2; }
+die() { err "$*"; exit 1; }
+log() { echo "[rancher-grant] $*" >&2; }
+
+forbidden_hint() {
+  err "API token lacks permission to manage cluster members (clusterRoleTemplateBindings)."
+  err "Use a Rancher admin or service-account API token with cluster membership rights."
+  err "Store it as RANCHER_API_TOKEN in the GitHub environment secret (not a personal restricted token)."
+}
+
+require_arg() {
+  local flag="$1"
+  [[ $# -ge 2 && -n "${2:-}" && "$2" != --* ]] || die "$flag requires a value"
+}
+
+urlencode() {
+  jq -rn --arg v "$1" '$v|@uri'
+}
+
+slugify() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rancher-url)         require_arg --rancher-url "${2-}";         RANCHER_URL="$2"; shift 2 ;;
+    --token)               require_arg --token "${2-}";               RANCHER_TOKEN="$2"; shift 2 ;;
+    --cluster-name)        require_arg --cluster-name "${2-}";        CLUSTER_NAME="$2"; shift 2 ;;
+    --cluster-id)          require_arg --cluster-id "${2-}";          CLUSTER_ID="$2"; shift 2 ;;
+    --group)               require_arg --group "${2-}";               GROUP_NAME="$2"; shift 2 ;;
+    --group-principal-id)  require_arg --group-principal-id "${2-}";  GROUP_PRINCIPAL_ID="$2"; shift 2 ;;
+    --role-template)       require_arg --role-template "${2-}";       ROLE_TEMPLATE_ID="$2"; shift 2 ;;
+    --group-auth-prefix)   require_arg --group-auth-prefix "${2-}";   GROUP_AUTH_PREFIX="$2"; shift 2 ;;
+    --binding-name)        require_arg --binding-name "${2-}";        BINDING_NAME="$2"; shift 2 ;;
+    --list-bindings)       LIST_BINDINGS="true"; shift ;;
+    --fix-misbound-user)   FIX_MISBOUND_USER="true"; shift ;;
+    --insecure)            INSECURE="true"; shift ;;
+    -h|--help)             usage; exit 0 ;;
+    *)                     die "Unknown argument: $1 (use --help)" ;;
+  esac
+done
+
+[[ ${BASH_VERSINFO[0]} -ge 4 ]] || die "bash 4+ is required"
+[[ -n "$RANCHER_URL" ]]          || die "--rancher-url is required"
+[[ -n "$RANCHER_TOKEN" ]]         || die "--token is required"
+[[ -n "$CLUSTER_NAME" || -n "$CLUSTER_ID" ]] || die "--cluster-name or --cluster-id is required"
+if [[ "$LIST_BINDINGS" != "true" ]]; then
+  [[ -n "$GROUP_NAME" || -n "$GROUP_PRINCIPAL_ID" ]] || die "--group or --group-principal-id is required"
+fi
+command -v curl >/dev/null 2>&1 || die "curl is required"
+command -v jq   >/dev/null 2>&1 || die "jq is required"
+
+if [[ -z "$GROUP_NAME" && -n "$GROUP_PRINCIPAL_ID" ]]; then
+  GROUP_NAME="${GROUP_PRINCIPAL_ID##*/}"
+fi
+
+RANCHER_URL="${RANCHER_URL%/}"
+[[ "$RANCHER_URL" =~ ^https:// ]] \
+  || die "RANCHER_URL must begin with https:// (got: $RANCHER_URL)"
+
+api() {
+  local method="$1" path="$2" body="${3:-}"
+  local tmp status curl_args=()
+  tmp="$(mktemp "${TMPDIR:-/tmp}/rancher-api.XXXXXX")"
+  trap "rm -f $(printf %q "$tmp")" RETURN
+
+  curl_args=(
+    -sS
+    -o "$tmp"
+    -w "%{http_code}"
+    -X "$method"
+    -H "Authorization: Bearer ${RANCHER_TOKEN}"
+    -H "Content-Type: application/json"
+    -H "Accept: application/json"
+    --connect-timeout 10
+    --max-time 60
+  )
+  [[ "$INSECURE" == "true" ]] && curl_args+=(-k)
+  [[ -n "$body" ]] && curl_args+=(-d "$body")
+
+  if ! status="$(curl "${curl_args[@]}" "${RANCHER_URL}${path}")"; then
+    LAST_HTTP_STATUS=""
+    err "Rancher API ${method} ${path}: curl failed"
+    [[ -s "$tmp" ]] && cat "$tmp" >&2
+    return 1
+  fi
+
+  LAST_HTTP_STATUS="$status"
+  if [[ ! "$status" =~ ^[0-9]+$ ]] || (( status >= 400 )); then
+    err "Rancher API ${method} ${path} failed with HTTP ${status:-unknown}"
+    [[ -s "$tmp" ]] && cat "$tmp" >&2
+    [[ "$status" == "403" ]] && forbidden_hint
+    return 1
+  fi
+
+  cat "$tmp"
+}
+
+fetch_cluster_id_by_name() {
+  local json count id
+  if ! json="$(api GET "/v3/clusters?name=$(urlencode "$CLUSTER_NAME")")"; then
+    die "Failed to query Rancher clusters by name"
+  fi
+  count="$(jq -r --arg name "$CLUSTER_NAME" '[.data[]? | select(.name == $name)] | length' <<<"$json")"
+  if (( count > 1 )); then
+    die "Multiple Rancher clusters named '$CLUSTER_NAME'; resolve duplicates manually"
+  fi
+  id="$(jq -r --arg name "$CLUSTER_NAME" '[.data[]? | select(.name == $name)][0].id // empty' <<<"$json")"
+  [[ -n "$id" ]] || return 1
+  printf '%s' "$id"
+}
+
+detect_group_auth_prefix() {
+  local json provider
+  if ! json="$(api GET "/v3/authconfigs")"; then
+    log "Could not list auth configs; defaulting to keycloak_group (MOSIP Keycloak SAML)"
+    printf '%s' "keycloak_group"
+    return 0
+  fi
+  provider="$(jq -r '
+    [.data[]? |
+      select((.enabled // false) == true) |
+      (.type // "") | sub("Config$"; "")
+    ] |
+    map(select(test("^(keycloakoidc|keycloak|openldap|azuread|activedirectory|okta|github|google)$"))) |
+    .[0] // empty
+  ' <<<"$json")"
+  case "$provider" in
+    keycloakoidc)      printf '%s' "keycloakoidc_group" ;;
+    keycloak)          printf '%s' "keycloak_group" ;;
+    openldap)          printf '%s' "openldap_group" ;;
+    azuread)           printf '%s' "azuread_group" ;;
+    activedirectory)   printf '%s' "activedirectory_group" ;;
+    okta)              printf '%s' "okta_group" ;;
+    github)            printf '%s' "github_group" ;;
+    google)            printf '%s' "google_group" ;;
+    *)
+      log "No known external auth provider detected (enabled=$provider); defaulting to keycloak_group"
+      printf '%s' "keycloak_group"
+      ;;
+  esac
+}
+
+is_group_principal() {
+  local principal="$1"
+  [[ "$principal" == *"_group://"* ]]
+}
+
+validate_group_principal() {
+  local principal="$1"
+  if is_group_principal "$principal"; then
+    return 0
+  fi
+  err "Principal is not a group (expected id containing '_group://'): ${principal}"
+  return 1
+}
+
+search_group_principal_id() {
+  local name="$1" json principal
+  if ! json="$(api POST "/v3/principals?action=search" "$(jq -nc --arg name "$name" '{name: $name, principalType: "grp"}')")"; then
+    return 1
+  fi
+  principal="$(jq -r --arg name "$name" '
+    [.data[]? |
+      select((.id // "") | test("_group://")) |
+      select((.id // "") | test("_user://") | not) |
+      select((.principalType // "") == "grp" or (.principalType // "") == "group") |
+      select((.name // "") == $name or (.loginName // "") == $name or (.displayName // "") == $name)
+    ][0].id // empty
+  ' <<<"$json")"
+  [[ -n "$principal" ]] || return 1
+  validate_group_principal "$principal"
+  printf '%s' "$principal"
+}
+
+constructed_group_principal_ids() {
+  local prefix="$1" name="$2"
+  # MOSIP Keycloak SAML uses keycloak_group://DEVOPS (two slashes), not ///DEVOPS.
+  if [[ "$prefix" == "keycloak_group" ]]; then
+    printf '%s\n' \
+      "${prefix}://${name}" \
+      "${prefix}:///${name}"
+    return 0
+  fi
+  printf '%s\n' \
+    "${prefix}://${name}" \
+    "${prefix}:///${name}"
+}
+
+resolve_group_principal_id() {
+  local prefix candidate
+  if [[ -n "$GROUP_PRINCIPAL_ID" ]]; then
+    validate_group_principal "$GROUP_PRINCIPAL_ID" \
+      || die "GROUP_PRINCIPAL_ID must be a group principal (e.g. keycloak_group://DEVOPS)"
+    printf '%s' "$GROUP_PRINCIPAL_ID"
+    return 0
+  fi
+
+  if [[ -z "$GROUP_AUTH_PREFIX" ]]; then
+    GROUP_AUTH_PREFIX="$(detect_group_auth_prefix)"
+    log "Using group auth prefix: ${GROUP_AUTH_PREFIX}"
+  fi
+
+  while IFS= read -r candidate; do
+    log "Trying constructed group principal: ${candidate}"
+    printf '%s' "$candidate"
+    return 0
+  done < <(constructed_group_principal_ids "$GROUP_AUTH_PREFIX" "$GROUP_NAME")
+
+  if candidate="$(search_group_principal_id "$GROUP_NAME" || true)" && [[ -n "$candidate" ]]; then
+    log "Resolved group principal via Rancher search: ${candidate}"
+    printf '%s' "$candidate"
+    return 0
+  fi
+
+  die "Could not resolve a group principal for '${GROUP_NAME}'"
+}
+
+alternate_group_principal_ids() {
+  local prefix="$1" name="$2"
+  constructed_group_principal_ids "$prefix" "$name"
+  printf '%s\n' \
+    "keycloakoidc_group://${name}" \
+    "keycloakoidc_group:///${name}" \
+    "keycloak_group://${name}" \
+    "keycloak_group:///${name}"
+}
+
+delete_binding_by_id() {
+  local id="$1"
+  if api DELETE "/v3/clusterroletemplatebindings/$(urlencode "$id")" >/dev/null; then
+    DELETIONS_PERFORMED="true"
+    return 0
+  fi
+  return 1
+}
+
+unique_binding_suffix() {
+  printf '%04x' "$((RANDOM % 65536))"
+}
+
+planned_binding_name() {
+  local binding_label="${GROUP_NAME:-${GROUP_PRINCIPAL_ID##*/}}"
+  if [[ -n "$BINDING_NAME" ]]; then
+    printf '%s' "$BINDING_NAME"
+    return 0
+  fi
+  if [[ "$DELETIONS_PERFORMED" == "true" ]]; then
+    printf 'crtb-%s-%s-%s' \
+      "$(slugify "$binding_label")" \
+      "$(slugify "$ROLE_TEMPLATE_ID")" \
+      "$(unique_binding_suffix)"
+    return 0
+  fi
+  printf 'crtb-%s-%s' "$(slugify "$binding_label")" "$(slugify "$ROLE_TEMPLATE_ID")"
+}
+
+binding_name_exists() {
+  local name="$1" json
+  if ! json="$(api GET "/v3/clusterroletemplatebindings?clusterId=$(urlencode "$CLUSTER_ID")")"; then
+    return 1
+  fi
+  jq -e --arg name "$name" '.data[]? | select(.name == $name)' <<<"$json" >/dev/null
+}
+
+update_group_binding() {
+  local id="$1" name="$2" principal="$3" body
+  body="$(jq -nc \
+    --arg type "clusterRoleTemplateBinding" \
+    --arg id "$id" \
+    --arg name "$name" \
+    --arg clusterId "$CLUSTER_ID" \
+    --arg groupPrincipalId "$principal" \
+    --arg roleTemplateId "$ROLE_TEMPLATE_ID" \
+    '{
+      type: $type,
+      id: $id,
+      name: $name,
+      clusterId: $clusterId,
+      groupPrincipalId: $groupPrincipalId,
+      roleTemplateId: $roleTemplateId
+    }')"
+  api PUT "/v3/clusterroletemplatebindings/$(urlencode "$id")" "$body" >/dev/null
+}
+
+remove_misbound_user_bindings() {
+  local json ids id principal
+  if ! json="$(api GET "/v3/clusterroletemplatebindings?clusterId=$(urlencode "$CLUSTER_ID")")"; then
+    err "Could not list bindings while checking for misbound user entries"
+    return 1
+  fi
+  mapfile -t ids < <(jq -r --arg name "$GROUP_NAME" '
+    [.data[]? |
+      select((.userPrincipalId // "") != "") |
+      select((.groupPrincipalId // "") == "") |
+      select(
+        (.userPrincipalId // "") | endswith("/" + $name) or endswith("://" + $name) or endswith($name)
+      ) |
+      .id
+    ] | .[]
+  ' <<<"$json")
+  for id in "${ids[@]}"; do
+    [[ -n "$id" ]] || continue
+    principal="$(jq -r --arg id "$id" '[.data[]? | select(.id == $id)][0].userPrincipalId // empty' <<<"$json")"
+    log "Removing misbound user clusterRoleTemplateBinding id=${id} userPrincipalId=${principal}"
+    delete_binding_by_id "$id" || err "Failed to delete binding ${id}"
+  done
+}
+
+reconcile_stale_group_bindings() {
+  local target="$1" json rows id name principal role
+  [[ -n "$GROUP_NAME" ]] || return 0
+  if ! json="$(api GET "/v3/clusterroletemplatebindings?clusterId=$(urlencode "$CLUSTER_ID")")"; then
+    err "Could not list bindings while reconciling stale group entries"
+    return 1
+  fi
+  while IFS=$'\t' read -r id name principal role; do
+    [[ -n "$id" ]] || continue
+    if [[ "$role" == "$ROLE_TEMPLATE_ID" ]]; then
+      log "Repairing group clusterRoleTemplateBinding id=${id} groupPrincipalId=${principal} -> ${target}"
+      if update_group_binding "$id" "$name" "$target"; then
+        REPAIRS_PERFORMED="true"
+      else
+        log "Repair failed; deleting binding id=${id}"
+        delete_binding_by_id "$id" || err "Failed to delete binding ${id}"
+      fi
+      continue
+    fi
+    log "Removing stale group clusterRoleTemplateBinding id=${id} groupPrincipalId=${principal} role=${role}"
+    delete_binding_by_id "$id" || err "Failed to delete binding ${id}"
+  done < <(jq -r --arg target "$target" --arg name "$GROUP_NAME" --arg role "$ROLE_TEMPLATE_ID" '
+    [.data[]? |
+      select((.groupPrincipalId // "") != "") |
+      select((.groupPrincipalId // "") != $target) |
+      select(
+        (.groupPrincipalId // "") |
+        test("keycloak_(group|user):///?" + $name + "$")
+      ) |
+      [.id, .name, .groupPrincipalId, .roleTemplateId] |
+      @tsv
+    ] | .[]
+  ' <<<"$json")
+}
+
+remove_stale_role_bindings() {
+  local target="$1" json ids id role
+  if ! json="$(api GET "/v3/clusterroletemplatebindings?clusterId=$(urlencode "$CLUSTER_ID")")"; then
+    err "Could not list bindings while checking for stale role entries"
+    return 1
+  fi
+  mapfile -t ids < <(jq -r --arg target "$target" --arg role "$ROLE_TEMPLATE_ID" '
+    [.data[]? |
+      select((.groupPrincipalId // "") == $target) |
+      select((.roleTemplateId // "") != $role) |
+      .id
+    ] | .[]
+  ' <<<"$json")
+  for id in "${ids[@]}"; do
+    [[ -n "$id" ]] || continue
+    role="$(jq -r --arg id "$id" '[.data[]? | select(.id == $id)][0].roleTemplateId // empty' <<<"$json")"
+    log "Removing stale role clusterRoleTemplateBinding id=${id} groupPrincipalId=${target} role=${role}"
+    delete_binding_by_id "$id" || err "Failed to delete binding ${id}"
+  done
+}
+
+binding_exists() {
+  local principal="$1" json
+  if ! json="$(api GET "/v3/clusterroletemplatebindings?clusterId=$(urlencode "$CLUSTER_ID")")"; then
+    die "Failed to list cluster role template bindings"
+  fi
+  jq -e --arg gid "$principal" --arg role "$ROLE_TEMPLATE_ID" '
+    (.data // [])[] |
+    select((.groupPrincipalId // "") == $gid and (.roleTemplateId // "") == $role)
+  ' <<<"$json" >/dev/null
+}
+
+list_cluster_bindings() {
+  local json
+  if ! json="$(api GET "/v3/clusterroletemplatebindings?clusterId=$(urlencode "$CLUSTER_ID")")"; then
+    die "Failed to list cluster role template bindings"
+  fi
+  jq '[.data[]? | {
+    id,
+    name,
+    roleTemplateId,
+    groupPrincipalId,
+    userPrincipalId,
+    userId
+  }]' <<<"$json"
+}
+
+log_cluster_bindings() {
+  log "Current clusterRoleTemplateBindings on ${CLUSTER_ID}:"
+  list_cluster_bindings | jq -c '.[]' >&2 || true
+}
+
+create_binding() {
+  local principal="$1" body response binding_label attempt max_attempts=10
+  validate_group_principal "$principal" || return 1
+  binding_label="${GROUP_NAME:-${principal##*/}}"
+  if [[ -z "$BINDING_NAME" ]]; then
+    BINDING_NAME="$(planned_binding_name)"
+  fi
+
+  for (( attempt=1; attempt<=max_attempts; attempt++ )); do
+    body="$(jq -nc \
+      --arg type "clusterRoleTemplateBinding" \
+      --arg name "$BINDING_NAME" \
+      --arg clusterId "$CLUSTER_ID" \
+      --arg groupPrincipalId "$principal" \
+      --arg roleTemplateId "$ROLE_TEMPLATE_ID" \
+      '{
+        type: $type,
+        name: $name,
+        clusterId: $clusterId,
+        groupPrincipalId: $groupPrincipalId,
+        roleTemplateId: $roleTemplateId
+      }')"
+
+    if response="$(api POST "/v3/clusterroletemplatebindings" "$body")"; then
+      jq -r '{id, name, clusterId, groupPrincipalId, roleTemplateId}' <<<"$response" >&2
+      return 0
+    fi
+    if [[ "${LAST_HTTP_STATUS:-}" == "403" ]]; then
+      return 2
+    fi
+    if [[ "${LAST_HTTP_STATUS:-}" == "409" ]]; then
+      BINDING_NAME="crtb-$(slugify "$binding_label")-$(slugify "$ROLE_TEMPLATE_ID")-$(unique_binding_suffix)"
+      log "Binding name conflict (attempt ${attempt}/${max_attempts}); retrying as '${BINDING_NAME}' ..."
+      continue
+    fi
+    return 1
+  done
+  [[ "${LAST_HTTP_STATUS:-}" == "409" ]] && return 3
+  return 1
+}
+
+if [[ -z "$CLUSTER_ID" ]]; then
+  log "Looking up cluster '${CLUSTER_NAME}' in Rancher ..."
+  if ! CLUSTER_ID="$(fetch_cluster_id_by_name)"; then
+    die "Cluster '$CLUSTER_NAME' not found in Rancher"
+  fi
+fi
+log "Target cluster id=${CLUSTER_ID}"
+
+if [[ "$LIST_BINDINGS" == "true" ]]; then
+  list_cluster_bindings
+  exit 0
+fi
+
+GROUP_PRINCIPAL_ID="$(resolve_group_principal_id)"
+validate_group_principal "$GROUP_PRINCIPAL_ID" \
+  || die "Refusing to bind a non-group principal: ${GROUP_PRINCIPAL_ID}"
+
+if [[ "$FIX_MISBOUND_USER" == "true" && -n "$GROUP_NAME" ]]; then
+  remove_misbound_user_bindings || true
+  reconcile_stale_group_bindings "$GROUP_PRINCIPAL_ID" || true
+  remove_stale_role_bindings "$GROUP_PRINCIPAL_ID" || true
+fi
+
+log "Granting role '${ROLE_TEMPLATE_ID}' to group '${GROUP_NAME:-$GROUP_PRINCIPAL_ID}' on cluster '${CLUSTER_ID}' ..."
+
+if binding_exists "$GROUP_PRINCIPAL_ID"; then
+  log "Binding already exists for group='${GROUP_PRINCIPAL_ID}' role='${ROLE_TEMPLATE_ID}' (skipping)"
+  log_cluster_bindings
+  exit 0
+fi
+
+BINDING_NAME=""
+create_status=0
+create_binding "$GROUP_PRINCIPAL_ID" || create_status=$?
+if (( create_status == 0 )); then
+  log "Cluster access granted successfully"
+  log_cluster_bindings
+  exit 0
+fi
+if (( create_status == 2 )); then
+  die "Cannot grant cluster access: Rancher API token is forbidden from managing cluster members."
+fi
+if (( create_status == 3 )); then
+  die "Cannot grant cluster access: Rancher rejected all generated binding names; re-run the workflow in a few minutes."
+fi
+
+if (( create_status == 1 )) && [[ "${LAST_HTTP_STATUS:-}" != "409" ]] && [[ -n "$GROUP_NAME" ]]; then
+  prefix="${GROUP_AUTH_PREFIX:-}"
+  [[ -z "$prefix" ]] && prefix="$(detect_group_auth_prefix)"
+  while IFS= read -r candidate; do
+    [[ "$candidate" == "$GROUP_PRINCIPAL_ID" ]] && continue
+    log "Retrying with alternate group principal: ${candidate}"
+    if binding_exists "$candidate"; then
+      log "Binding already exists for group='${candidate}' role='${ROLE_TEMPLATE_ID}' (skipping)"
+      exit 0
+    fi
+    BINDING_NAME=""
+    create_status=0
+    create_binding "$candidate" || create_status=$?
+    if (( create_status == 0 )); then
+      log "Cluster access granted successfully with principal '${candidate}'"
+      log_cluster_bindings
+      exit 0
+    fi
+    if (( create_status == 2 )); then
+      die "Cannot grant cluster access: Rancher API token is forbidden from managing cluster members."
+    fi
+    if (( create_status == 3 )); then
+      die "Cannot grant cluster access: Rancher rejected all generated binding names; re-run the workflow in a few minutes."
+    fi
+  done < <(alternate_group_principal_ids "$prefix" "$GROUP_NAME")
+fi
+
+die "Failed to create clusterRoleTemplateBinding. Set RANCHER_GROUP_PRINCIPAL_ID=keycloak_group://DEVOPS (or pass --group-principal-id) and ensure RANCHER_API_TOKEN can manage cluster members."

--- a/.github/scripts/rancher-grant-cluster-access.sh
+++ b/.github/scripts/rancher-grant-cluster-access.sh
@@ -228,24 +228,6 @@ validate_group_principal() {
   return 1
 }
 
-search_group_principal_id() {
-  local name="$1" json principal
-  if ! json="$(api POST "/v3/principals?action=search" "$(jq -nc --arg name "$name" '{name: $name, principalType: "grp"}')")"; then
-    return 1
-  fi
-  principal="$(jq -r --arg name "$name" '
-    [.data[]? |
-      select((.id // "") | test("_group://")) |
-      select((.id // "") | test("_user://") | not) |
-      select((.principalType // "") == "grp" or (.principalType // "") == "group") |
-      select((.name // "") == $name or (.loginName // "") == $name or (.displayName // "") == $name)
-    ][0].id // empty
-  ' <<<"$json")"
-  [[ -n "$principal" ]] || return 1
-  validate_group_principal "$principal"
-  printf '%s' "$principal"
-}
-
 constructed_group_principal_ids() {
   local prefix="$1" name="$2"
   # MOSIP Keycloak SAML uses keycloak_group://DEVOPS (two slashes), not ///DEVOPS.
@@ -261,7 +243,7 @@ constructed_group_principal_ids() {
 }
 
 resolve_group_principal_id() {
-  local prefix candidate
+  local candidate
   if [[ -n "$GROUP_PRINCIPAL_ID" ]]; then
     validate_group_principal "$GROUP_PRINCIPAL_ID" \
       || die "GROUP_PRINCIPAL_ID must be a group principal (e.g. keycloak_group://DEVOPS)"
@@ -274,19 +256,10 @@ resolve_group_principal_id() {
     log "Using group auth prefix: ${GROUP_AUTH_PREFIX}"
   fi
 
-  while IFS= read -r candidate; do
-    log "Trying constructed group principal: ${candidate}"
-    printf '%s' "$candidate"
-    return 0
-  done < <(constructed_group_principal_ids "$GROUP_AUTH_PREFIX" "$GROUP_NAME")
-
-  if candidate="$(search_group_principal_id "$GROUP_NAME" || true)" && [[ -n "$candidate" ]]; then
-    log "Resolved group principal via Rancher search: ${candidate}"
-    printf '%s' "$candidate"
-    return 0
-  fi
-
-  die "Could not resolve a group principal for '${GROUP_NAME}'"
+  IFS= read -r candidate < <(constructed_group_principal_ids "$GROUP_AUTH_PREFIX" "$GROUP_NAME")
+  [[ -n "$candidate" ]] || die "Could not resolve a group principal for '${GROUP_NAME}'"
+  log "Using constructed group principal: ${candidate}"
+  printf '%s' "$candidate"
 }
 
 alternate_group_principal_ids() {

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -426,8 +426,7 @@ jobs:
 
           printf '%s' "$KUBECONFIG_CONTENT" | gh secret set KUBECONFIG \
             --env "$REF_NAME" \
-            --repo "$GITHUB_REPOSITORY" \
-            --body -
+            --repo "$GITHUB_REPOSITORY"
           echo "Published KUBECONFIG environment secret for: $REF_NAME"
 
       - name: Add the Terraform plan file / *.tfstate files / terraform format changes

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -84,6 +84,11 @@ on:
         description: 'Rancher cluster name (defaults to branch/env name)'
         required: false
         type: string
+      PUBLISH_KUBECONFIG:
+        description: 'After infra apply, fetch kubeconfig from Rancher and set KUBECONFIG env secret (needs RANCHER_API_* secrets + import complete)'
+        required: false
+        type: boolean
+        default: true
         
 env:
   # TF_LOG_PATH: ./temp/terraform.log
@@ -389,6 +394,41 @@ jobs:
         run: terraform apply -input=false -var-file="$TFVARS_FILE" -no-color -auto-approve
         if: "${{ inputs.TERRAFORM_APPLY  == true }}"
         continue-on-error: true
+
+      - name: Publish KUBECONFIG from Rancher
+        if: ${{ inputs.TERRAFORM_COMPONENT == 'infra' && inputs.TERRAFORM_APPLY == true && inputs.PUBLISH_KUBECONFIG == true && steps.apply.outcome == 'success' }}
+        env:
+          RANCHER_URL: ${{ secrets.RANCHER_API_URL }}
+          RANCHER_TOKEN: ${{ secrets.RANCHER_API_TOKEN }}
+          RANCHER_CLUSTER_NAME_INPUT: ${{ inputs.RANCHER_CLUSTER_NAME }}
+          REF_NAME: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GH_INFRA_PAT }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          if [ -z "$RANCHER_URL" ] || [ -z "$RANCHER_TOKEN" ]; then
+            echo "Skipping KUBECONFIG publish: RANCHER_API_URL / RANCHER_API_TOKEN not set for environment '$REF_NAME'"
+            exit 0
+          fi
+          if [ -z "$GH_TOKEN" ]; then
+            echo "ERROR: GH_INFRA_PAT is required to publish KUBECONFIG environment secret"
+            exit 1
+          fi
+          command -v gh >/dev/null 2>&1 || { echo "ERROR: gh CLI is required"; exit 1; }
+
+          CLUSTER_NAME="${RANCHER_CLUSTER_NAME_INPUT:-$REF_NAME}"
+          echo "Fetching kubeconfig for Rancher cluster '$CLUSTER_NAME' ..."
+          chmod +x "$GITHUB_WORKSPACE/.github/scripts/rancher-fetch-kubeconfig.sh"
+
+          KUBECONFIG_CONTENT="$("$GITHUB_WORKSPACE/.github/scripts/rancher-fetch-kubeconfig.sh" \
+            --rancher-url "$RANCHER_URL" \
+            --token "$RANCHER_TOKEN" \
+            --cluster-name "$CLUSTER_NAME")"
+
+          printf '%s' "$KUBECONFIG_CONTENT" | gh secret set KUBECONFIG \
+            --env "$REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --body -
+          echo "Published KUBECONFIG environment secret for: $REF_NAME"
 
       - name: Add the Terraform plan file / *.tfstate files / terraform format changes
         run: |

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -89,6 +89,24 @@ on:
         required: false
         type: boolean
         default: true
+      RANCHER_DEVOPS_GROUP:
+        description: 'IdP group name granted cluster access on imported clusters (e.g. DEVOPS)'
+        required: false
+        type: string
+        default: 'DEVOPS'
+      GRANT_RANCHER_DEVOPS_ACCESS:
+        description: 'Grant RANCHER_DEVOPS_GROUP cluster access via Rancher API after registration'
+        required: false
+        type: boolean
+        default: true
+      RANCHER_DEVOPS_ROLE:
+        description: 'Rancher role for DEVOPS group (cluster-member = UI visibility; cluster-owner = full cluster admin)'
+        required: false
+        type: choice
+        options:
+          - cluster-member
+          - cluster-owner
+        default: cluster-owner
         
 env:
   # TF_LOG_PATH: ./temp/terraform.log
@@ -380,18 +398,85 @@ jobs:
             --rancher-url "$RANCHER_URL" \
             --token "$RANCHER_TOKEN" \
             --cluster-name "$CLUSTER_NAME" | tail -n1)"
-          echo "TF_VAR_rancher_import_url=$IMPORT_CMD" >> "$GITHUB_ENV"
-          echo "TF_VAR_enable_rancher_import=true" >> "$GITHUB_ENV"
+          # -var-file in tfvars overrides TF_VAR_* env vars. Write an override file so
+          # Ansible inventory gets enable_rancher_import=true and the minted import URL.
+          IMPORT_INNER="${IMPORT_CMD#\"}"
+          IMPORT_INNER="${IMPORT_INNER%\"}"
+          export IMPORT_INNER
+          # Use Python so YAML/runner quoting does not strip HCL escapes from printf.
+          python3 <<'PY' > rancher-override.tfvars
+          import os
+          
+          inner = os.environ["IMPORT_INNER"]
+          quoted = '"' + inner + '"'
+          hcl = '"' + quoted.replace('"', '\\"') + '"'
+          print("enable_rancher_import = true")
+          print(f"rancher_import_url    = {hcl}")
+          PY
+          echo "Generated rancher-override.tfvars:"
+          cat rancher-override.tfvars
+          echo "RANCHER_TFVARS_FILE=rancher-override.tfvars" >> "$GITHUB_ENV"
           echo "Rancher import URL minted for: $CLUSTER_NAME"
+
+      - name: Grant DevOps group cluster access in Rancher
+        if: ${{ inputs.TERRAFORM_COMPONENT == 'infra' && inputs.ENABLE_RANCHER_IMPORT == true && inputs.GRANT_RANCHER_DEVOPS_ACCESS == true }}
+        env:
+          RANCHER_URL: ${{ secrets.RANCHER_API_URL }}
+          RANCHER_TOKEN: ${{ secrets.RANCHER_API_TOKEN }}
+          RANCHER_CLUSTER_NAME_INPUT: ${{ inputs.RANCHER_CLUSTER_NAME }}
+          REF_NAME: ${{ github.ref_name }}
+          RANCHER_DEVOPS_GROUP: ${{ inputs.RANCHER_DEVOPS_GROUP }}
+          RANCHER_DEVOPS_ROLE: ${{ inputs.RANCHER_DEVOPS_ROLE }}
+          RANCHER_GROUP_AUTH_PREFIX: ${{ vars.RANCHER_GROUP_AUTH_PREFIX }}
+          RANCHER_GROUP_PRINCIPAL_ID: ${{ vars.RANCHER_GROUP_PRINCIPAL_ID }}
+        run: |
+          if [ -z "$RANCHER_URL" ] || [ -z "$RANCHER_TOKEN" ]; then
+            echo "ERROR: RANCHER_API_URL and RANCHER_API_TOKEN must be set for environment '$REF_NAME'"
+            exit 1
+          fi
+          if [ -z "$RANCHER_DEVOPS_GROUP" ]; then
+            echo "Skipping Rancher group grant: RANCHER_DEVOPS_GROUP is empty"
+            exit 0
+          fi
+          CLUSTER_NAME="${RANCHER_CLUSTER_NAME_INPUT:-$REF_NAME}"
+          echo "Granting ${RANCHER_DEVOPS_ROLE:-cluster-owner} to group '$RANCHER_DEVOPS_GROUP' on Rancher cluster '$CLUSTER_NAME' ..."
+          chmod +x "$GITHUB_WORKSPACE/.github/scripts/rancher-grant-cluster-access.sh"
+          ARGS=(
+            --rancher-url "$RANCHER_URL"
+            --token "$RANCHER_TOKEN"
+            --cluster-name "$CLUSTER_NAME"
+            --group "$RANCHER_DEVOPS_GROUP"
+            --role-template "${RANCHER_DEVOPS_ROLE:-cluster-owner}"
+            --fix-misbound-user
+          )
+          if [ -n "$RANCHER_GROUP_PRINCIPAL_ID" ]; then
+            ARGS+=(--group-principal-id "$RANCHER_GROUP_PRINCIPAL_ID")
+          else
+            ARGS+=(--group-auth-prefix keycloak_group)
+          fi
+          if [ -n "$RANCHER_GROUP_AUTH_PREFIX" ]; then
+            ARGS+=(--group-auth-prefix "$RANCHER_GROUP_AUTH_PREFIX")
+          fi
+          "$GITHUB_WORKSPACE/.github/scripts/rancher-grant-cluster-access.sh" "${ARGS[@]}"
+
       - name: Terraform Plan
         id: plan
         run: |
-          terraform plan -input=false -var-file="$TFVARS_FILE" -out ./tf-plan -no-color
+          TF_ARGS=(-input=false -var-file="$TFVARS_FILE")
+          if [ -n "${RANCHER_TFVARS_FILE:-}" ] && [ -f "$RANCHER_TFVARS_FILE" ]; then
+            TF_ARGS+=(-var-file="$RANCHER_TFVARS_FILE")
+          fi
+          terraform plan "${TF_ARGS[@]}" -out ./tf-plan -no-color
         continue-on-error: true
 
       - name: Terraform Apply
         id: apply
-        run: terraform apply -input=false -var-file="$TFVARS_FILE" -no-color -auto-approve
+        run: |
+          TF_ARGS=(-input=false -var-file="$TFVARS_FILE")
+          if [ -n "${RANCHER_TFVARS_FILE:-}" ] && [ -f "$RANCHER_TFVARS_FILE" ]; then
+            TF_ARGS+=(-var-file="$RANCHER_TFVARS_FILE")
+          fi
+          terraform apply "${TF_ARGS[@]}" -no-color -auto-approve
         if: "${{ inputs.TERRAFORM_APPLY  == true }}"
         continue-on-error: true
 
@@ -404,6 +489,8 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           GH_TOKEN: ${{ secrets.GH_INFRA_PAT }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          MAX_ATTEMPTS: "90"
+          SLEEP_SECONDS: "10"
         run: |
           if [ -z "$RANCHER_URL" ] || [ -z "$RANCHER_TOKEN" ]; then
             echo "Skipping KUBECONFIG publish: RANCHER_API_URL / RANCHER_API_TOKEN not set for environment '$REF_NAME'"
@@ -522,6 +609,7 @@ jobs:
         run: exit 1
 
       - uses: 8398a7/action-slack@v3
+        continue-on-error: true
         with:
           status: ${{ job.status }}
           fields: repo,message,author,commit,workflow,job # selectable (default: repo,message)


### PR DESCRIPTION
## Summary
- Add `rancher-fetch-kubeconfig.sh` to fetch cluster kubeconfig via Rancher `generateKubeconfig` API (stdout = raw YAML).
- Extend `terraform.yml` with `PUBLISH_KUBECONFIG` workflow input (default `true`) and a post-apply step that sets the `KUBECONFIG` GitHub environment secret via `gh secret set`.
- Skips gracefully when `RANCHER_API_URL` / `RANCHER_API_TOKEN` are not configured; requires `GH_INFRA_PAT` with environment secret write access.

## Test plan
- [ ] Run Terraform `infra` workflow with `TERRAFORM_APPLY=true`, `ENABLE_RANCHER_IMPORT=true`, `PUBLISH_KUBECONFIG=true` on a branch with Rancher env secrets
- [ ] Confirm **Publish KUBECONFIG from Rancher** step succeeds after cluster is Active
- [ ] Verify `KUBECONFIG` environment secret is created/updated on the branch environment
- [ ] Run `rancher-fetch-kubeconfig.sh` locally against an active imported cluster
- [ ] Re-run with `PUBLISH_KUBECONFIG=false` and confirm step is skipped


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `PUBLISH_KUBECONFIG` (default on) to publish a Kubernetes kubeconfig after a successful infrastructure deployment.
  * Added Rancher utilities to fetch a ready kubeconfig and to grant cluster role access to an authorization group.
* **Bug Fixes**
  * Improved resilience with stronger input validation, waiting for cluster readiness, and basic kubeconfig verification.
  * Enhanced workflow handling, including making Slack notifications non-blocking.
* **Chores**
  * Improved Terraform Rancher import variable handling and conditional application of role-access granting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->