### PR TITLE
Make Route53 DNS record creation optional via enable_route53_records

### DIFF
--- a/terraform/implementations/aws/infra/main.tf
+++ b/terraform/implementations/aws/infra/main.tf
@@ -65,6 +65,7 @@ module "mosip_infra" {
   ami                           = var.ami
   ssh_key_name                  = var.ssh_key_name
   zone_id                       = var.zone_id
+  enable_route53_records        = var.enable_route53_records
   vpc_name                      = var.vpc_name
   nginx_node_root_volume_size   = var.nginx_node_root_volume_size
   nginx_node_ebs_volume_size    = var.nginx_node_ebs_volume_size

--- a/terraform/implementations/aws/infra/profiles/esignet-standalone/aws.tfvars
+++ b/terraform/implementations/aws/infra/profiles/esignet-standalone/aws.tfvars
@@ -34,6 +34,10 @@ nginx_instance_type = "t3a.2xlarge"
 # The Route 53 hosted zone ID
 zone_id = "<route53_zone_id>"
 
+# Set to false if the domain's authoritative DNS is not Route53 (e.g. Azure DNS, Cloudflare, GoDaddy) —
+# infrastructure is still created, just without Route53 records. See DNS docs for the manual record list.
+enable_route53_records = true
+
 ## UBUNTU 24.04
 # The Amazon Machine Image ID for the instances
 ami = "ami-0ad21ae1d0696ad58"

--- a/terraform/implementations/aws/infra/profiles/mosip/aws.tfvars
+++ b/terraform/implementations/aws/infra/profiles/mosip/aws.tfvars
@@ -35,6 +35,10 @@ nginx_instance_type = "t3a.2xlarge"
 # The Route 53 hosted zone ID
 zone_id = "<route53_zone_id>"
 
+# Set to false if the domain's authoritative DNS is not Route53 (e.g. Azure DNS, Cloudflare, GoDaddy) —
+# infrastructure is still created, just without Route53 records. See DNS docs for the manual record list.
+enable_route53_records = true
+
 ## UBUNTU 24.04
 # The Amazon Machine Image ID for the instances
 ami = "ami-0ad21ae1d0696ad58"

--- a/terraform/implementations/aws/infra/variables.tf
+++ b/terraform/implementations/aws/infra/variables.tf
@@ -157,6 +157,12 @@ variable "zone_id" {
   type        = string
 }
 
+variable "enable_route53_records" {
+  description = "Whether to create Route53 DNS records. Set to false when the domain's authoritative DNS is not Route53 (e.g. Azure DNS, Cloudflare, GoDaddy)."
+  type        = bool
+  default     = true
+}
+
 variable "vpc_name" {
   description = "Name of the existing VPC (will be discovered by tag:Name)"
   type        = string

--- a/terraform/implementations/aws/observ-infra/aws.tfvars
+++ b/terraform/implementations/aws/observ-infra/aws.tfvars
@@ -40,6 +40,10 @@ ami = "ami-0ad21ae1d0696ad58"
 # Route53 zone ID for DNS records
 zone_id = "<zone-id>"
 
+# Set to false if the domain's authoritative DNS is not Route53 (e.g. Azure DNS, Cloudflare, GoDaddy) —
+# infrastructure is still created, just without Route53 records.
+enable_route53_records = true
+
 # VPC name (should match the one created by base-infra)
 vpc_name = "<vpc-name>"
 
@@ -78,7 +82,7 @@ keycloak_hostname = "iam.<cluster-env-domain>" # example iam.sandbox.xyz.net
 enable_rancher_keycloak_integration = true
 
 # Rancher import (same as infra)
-enable_rancher_import = false #dont enable for observ infra
+enable_rancher_import = false  #dont enable for observ infra
 rancher_import_url    = "\"\"" #dont update for observ infra
 
 # Security group CIDRs

--- a/terraform/implementations/aws/observ-infra/main.tf
+++ b/terraform/implementations/aws/observ-infra/main.tf
@@ -44,6 +44,7 @@ module "mosip_observ_infra" {
   ami                           = var.ami
   ssh_key_name                  = var.ssh_key_name
   zone_id                       = var.zone_id
+  enable_route53_records        = var.enable_route53_records
   vpc_name                      = var.vpc_name
   nginx_node_root_volume_size   = var.nginx_node_root_volume_size
   nginx_node_ebs_volume_size    = var.nginx_node_ebs_volume_size

--- a/terraform/implementations/aws/observ-infra/variables.tf
+++ b/terraform/implementations/aws/observ-infra/variables.tf
@@ -149,6 +149,12 @@ variable "zone_id" {
   type        = string
 }
 
+variable "enable_route53_records" {
+  description = "Whether to create Route53 DNS records. Set to false when the domain's authoritative DNS is not Route53 (e.g. Azure DNS, Cloudflare, GoDaddy)."
+  type        = bool
+  default     = true
+}
+
 variable "vpc_name" {
   description = "Name of the existing VPC (will be discovered by tag:Name)"
   type        = string

--- a/terraform/infra/aws/main.tf
+++ b/terraform/infra/aws/main.tf
@@ -30,6 +30,7 @@ module "aws_infrastructure" {
   NGINX_INSTANCE_TYPE           = var.nginx_instance_type
   AMI                           = var.ami
   ZONE_ID                       = var.zone_id
+  ENABLE_ROUTE53_RECORDS        = var.enable_route53_records
   K8S_INFRA_REPO_URL            = var.k8s_infra_repo_url
   K8S_INFRA_BRANCH              = var.k8s_infra_branch
   RKE2_VERSION                  = var.rke2_version

--- a/terraform/infra/aws/variables.tf
+++ b/terraform/infra/aws/variables.tf
@@ -101,6 +101,12 @@ variable "zone_id" {
   type        = string
 }
 
+variable "enable_route53_records" {
+  description = "Whether to create Route53 DNS records. Set to false when the domain's authoritative DNS is not Route53."
+  type        = bool
+  default     = true
+}
+
 variable "k8s_infra_repo_url" {
   description = "The URL of the Kubernetes infrastructure GitHub repository"
   type        = string

--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -36,6 +36,7 @@ module "aws_infra" {
   ssh_key_name                  = var.ssh_key_name
   ssh_private_key               = var.ssh_private_key
   zone_id                       = var.zone_id
+  enable_route53_records        = var.enable_route53_records
   vpc_name                      = var.vpc_name
   mosip_email_id                = var.mosip_email_id
   subdomain_public              = var.subdomain_public

--- a/terraform/infra/variables.tf
+++ b/terraform/infra/variables.tf
@@ -168,6 +168,12 @@ variable "zone_id" {
   default     = ""
 }
 
+variable "enable_route53_records" {
+  description = "Whether to create Route53 DNS records (AWS only). Set to false when the domain's authoritative DNS is not Route53."
+  type        = bool
+  default     = true
+}
+
 variable "vpc_name" {
   description = "Name of the existing VPC (will be discovered by tag:Name)"
   type        = string

--- a/terraform/modules/aws/aws-main.tf
+++ b/terraform/modules/aws/aws-main.tf
@@ -124,6 +124,7 @@ module "aws-resource-creation" {
   NGINX_INSTANCE_TYPE           = var.NGINX_INSTANCE_TYPE
   CLUSTER_ENV_DOMAIN            = var.CLUSTER_ENV_DOMAIN
   ZONE_ID                       = var.ZONE_ID
+  ENABLE_ROUTE53_RECORDS        = var.ENABLE_ROUTE53_RECORDS
   AMI                           = var.AMI
   K8S_INSTANCE_ROOT_VOLUME_SIZE = var.K8S_INSTANCE_ROOT_VOLUME_SIZE
 

--- a/terraform/modules/aws/aws-resource-creation/aws-resource-creation-main.tf
+++ b/terraform/modules/aws/aws-resource-creation/aws-resource-creation-main.tf
@@ -218,7 +218,7 @@ resource "aws_instance" "K8S_CLUSTER_EC2_INSTANCE" {
     Cluster   = local.K8S_EC2_NODE.tags.Cluster
     Component = var.CLUSTER_NAME
   }
-  
+
   lifecycle {
     # Create new instances before destroying old ones during updates
     create_before_destroy = true
@@ -290,7 +290,7 @@ resource "aws_route53_record" "DNS_RECORDS" {
     null_resource.k8s_status_checks
   ]
 
-  for_each = merge(local.MAP_DNS_TO_IP, var.DNS_RECORDS)
+  for_each = var.ENABLE_ROUTE53_RECORDS ? merge(local.MAP_DNS_TO_IP, var.DNS_RECORDS) : {}
   name     = each.value.name
   type     = each.value.type
   zone_id  = each.value.zone_id

--- a/terraform/modules/aws/aws-resource-creation/variables.tf
+++ b/terraform/modules/aws/aws-resource-creation/variables.tf
@@ -43,6 +43,11 @@ variable "NGINX_INSTANCE_TYPE" {
 }
 variable "CLUSTER_ENV_DOMAIN" { type = string }
 variable "ZONE_ID" { type = string }
+variable "ENABLE_ROUTE53_RECORDS" {
+  description = "Whether to create Route53 DNS records. Set to false when the domain's authoritative DNS is not Route53 (e.g. Azure DNS, Cloudflare, GoDaddy) — infrastructure is still created, just without Route53 records."
+  type        = bool
+  default     = true
+}
 variable "NGINX_NODE_ROOT_VOLUME_SIZE" { type = number }
 variable "NGINX_NODE_EBS_VOLUME_SIZE" { type = number }
 variable "NGINX_NODE_EBS_VOLUME_SIZE_2" { type = number }

--- a/terraform/modules/aws/variables.tf
+++ b/terraform/modules/aws/variables.tf
@@ -112,6 +112,11 @@ variable "AMI" {
 }
 
 variable "ZONE_ID" { type = string }
+variable "ENABLE_ROUTE53_RECORDS" {
+  description = "Whether to create Route53 DNS records. Set to false when the domain's authoritative DNS is not Route53."
+  type        = bool
+  default     = true
+}
 variable "K8S_INFRA_REPO_URL" {
   description = "The URL of the Kubernetes infrastructure GitHub repository"
   type        = string

--- a/terraform/observ-infra/aws/main.tf
+++ b/terraform/observ-infra/aws/main.tf
@@ -30,6 +30,7 @@ module "aws_observation_infrastructure" {
   NGINX_INSTANCE_TYPE           = var.nginx_instance_type
   AMI                           = var.ami
   ZONE_ID                       = var.zone_id
+  ENABLE_ROUTE53_RECORDS        = var.enable_route53_records
   K8S_INFRA_REPO_URL            = var.k8s_infra_repo_url
   K8S_INFRA_BRANCH              = var.k8s_infra_branch
   RKE2_VERSION                  = var.rke2_version
@@ -39,8 +40,8 @@ module "aws_observation_infrastructure" {
   nginx_node_ebs_volume_size_2  = var.nginx_node_ebs_volume_size_2
   K8S_INSTANCE_ROOT_VOLUME_SIZE = var.k8s_instance_root_volume_size
   network_cidr                  = var.network_cidr
-  NGINX_TYPE                    = "observability"  # Set NGINX type for observation infrastructure
-  DEPLOYMENT_TYPE               = "observ-infra"   # Set deployment type for correct kubeconfig path
+  NGINX_TYPE                    = "observability" # Set NGINX type for observation infrastructure
+  DEPLOYMENT_TYPE               = "observ-infra"  # Set deployment type for correct kubeconfig path
   WIREGUARD_CIDR                = var.WIREGUARD_CIDR
 
   # Disable PostgreSQL setup for observ-infra

--- a/terraform/observ-infra/aws/variables.tf
+++ b/terraform/observ-infra/aws/variables.tf
@@ -57,6 +57,11 @@ variable "zone_id" {
   type        = string
   description = "Route53 hosted zone ID"
 }
+variable "enable_route53_records" {
+  type        = bool
+  description = "Whether to create Route53 DNS records. Set to false when the domain's authoritative DNS is not Route53."
+  default     = true
+}
 variable "vpc_name" {
   type        = string
   description = "Name of the existing VPC (will be discovered by tag:Name)"

--- a/terraform/observ-infra/main.tf
+++ b/terraform/observ-infra/main.tf
@@ -36,6 +36,7 @@ module "aws_observ_infra" {
   ssh_key_name                  = var.ssh_key_name
   ssh_private_key               = var.ssh_private_key
   zone_id                       = var.zone_id
+  enable_route53_records        = var.enable_route53_records
   vpc_name                      = var.vpc_name
   mosip_email_id                = var.mosip_email_id
   subdomain_public              = var.subdomain_public

--- a/terraform/observ-infra/variables.tf
+++ b/terraform/observ-infra/variables.tf
@@ -160,6 +160,12 @@ variable "zone_id" {
   default     = ""
 }
 
+variable "enable_route53_records" {
+  description = "Whether to create Route53 DNS records (AWS only). Set to false when the domain's authoritative DNS is not Route53."
+  type        = bool
+  default     = true
+}
+
 variable "vpc_name" {
   description = "Name of the existing VPC (will be discovered by tag:Name)"
   type        = string


### PR DESCRIPTION
## Summary
- Adds an `enable_route53_records` toggle (default `true`, so existing deployments are unaffected) threaded through both the main MOSIP infra and observability infra AWS Terraform chains, down to the `aws_route53_record.DNS_RECORDS` resource in `aws-resource-creation`.
- When set to `false`, all infrastructure (EC2, K8s, NGINX, security groups) is still created, but no Route53 records are written — this lets the module be used with domains whose authoritative DNS is not Route53 (e.g. Azure DNS, Cloudflare, GoDaddy).
- The operator creates the equivalent A/CNAME records manually against the same `api`/`api-internal` + subdomain structure the module would otherwise create automatically. NGINX vhost/cert config (`CLUSTER_ENV_DOMAIN`, `MOSIP_PUBLIC_DOMAIN_LIST`) is unaffected either way, since it's derived from input variables rather than the created Route53 resource.

Fixes: mosip/mosip-infra#1916

## Test plan
- [ ] `terraform validate` passes for `terraform/implementations/aws/infra` and `terraform/implementations/aws/observ-infra` (verified locally)
- [ ] `terraform plan` with `enable_route53_records = true` (default) shows no changes to existing deployments
- [ ] `terraform plan`/`apply` with `enable_route53_records = false` creates infra without any `aws_route53_record` resources