### PR TITLE
docs: add GH_INFRA_PAT section to SECRET_GENERATION_GUIDE.md

### DIFF
--- a/Rancher-keycloak-integration/README.md
+++ b/Rancher-keycloak-integration/README.md
@@ -10,6 +10,36 @@ Automated setup for Keycloak and Rancher SAML authentication using GitHub Action
 - Keycloak admin credentials
 - Rancher API token
 
+## 🔧 How to Get Required Credentials
+
+### Rancher API Token
+
+1. Login to Rancher UI
+2. Click on your user profile (top right)
+3. Select **API & Keys**
+4. Click **Add Key**
+5. Provide a description and set expiration
+6. Click **Create**
+7. Copy the generated token (format: `token-xxxxx:xxxxxxxxxxxxxxxx`)
+
+### WireGuard Configuration
+
+The `TF_WG_CONFIG` secret should contain a valid WireGuard configuration:
+
+```ini
+[Interface]
+PrivateKey = <your-private-key>
+Address = <your-vpn-ip>/32
+
+[Peer]
+PublicKey = <server-public-key>
+AllowedIPs = <allowed-ip-range>
+Endpoint = <vpn-endpoint>:51820
+PersistentKeepalive = 25
+```
+
+---
+
 ## 🚀 Quick Start (Using GitHub Actions Workflow)
 
 The recommended approach is to use the **Keycloak-Rancher SAML Integration** workflow.
@@ -65,36 +95,6 @@ After successful workflow completion:
 2. Go to **Users & Authentication** → **Auth Provider**
 3. Verify Keycloak SAML is configured and enabled
 4. Test login using Keycloak credentials
-
-## 🔧 How to Get Required Credentials
-
-### Rancher API Token
-
-1. Login to Rancher UI
-2. Click on your user profile (top right)
-3. Select **API & Keys**
-4. Click **Add Key**
-5. Provide a description and set expiration
-6. Click **Create**
-7. Copy the generated token (format: `token-xxxxx:xxxxxxxxxxxxxxxx`)
-
-### WireGuard Configuration
-
-The `TF_WG_CONFIG` secret should contain a valid WireGuard configuration:
-
-```ini
-[Interface]
-PrivateKey = <your-private-key>
-Address = <your-vpn-ip>/32
-
-[Peer]
-PublicKey = <server-public-key>
-AllowedIPs = <allowed-ip-range>
-Endpoint = <vpn-endpoint>:51820
-PersistentKeepalive = 25
-```
-
----
 
 ## 📦 What the Workflow Does
 

--- a/docs/SECRET_GENERATION_GUIDE.md
+++ b/docs/SECRET_GENERATION_GUIDE.md
@@ -7,10 +7,11 @@ This guide provides step-by-step instructions for generating all required secret
 1. [SSH Keys](#1-ssh-keys)
 2. [GPG Passphrase](#2-gpg-passphrase)
 3. [AWS Credentials](#3-aws-credentials)
-4. [WireGuard VPN Configuration](#4-wireguard-vpn-configuration)
-5. [Kubernetes Config (KUBECONFIG)](#5-kubernetes-config-kubeconfig)
-6. [reCAPTCHA Keys](#6-recaptcha-keys)
-7. [How to Add Secrets to GitHub](#how-to-add-secrets-to-github)
+4. [GitHub Personal Access Token (GH_INFRA_PAT)](#4-github-personal-access-token-gh_infra_pat) — required for signup workflow auto-trigger and repository operations
+5. [WireGuard VPN Configuration](#5-wireguard-vpn-configuration)
+6. [Kubernetes Config (KUBECONFIG)](#6-kubernetes-config-kubeconfig)
+7. [reCAPTCHA Keys](#7-recaptcha-keys)
+8. [How to Add Secrets to GitHub](#8-how-to-add-secrets-to-github)
 
 ---
 
@@ -277,7 +278,66 @@ Add as **Repository Secrets** in GitHub:
 
 ---
 
-## 4. WireGuard VPN Configuration
+## 4. GitHub Personal Access Token (GH_INFRA_PAT)
+
+### What is it?
+A Fine-grained Personal Access Token (PAT) that allows GitHub Actions workflows to interact with your repository and dispatch other workflows via the GitHub API.
+
+### Why do you need it?
+
+`GH_INFRA_PAT` is used in two places inside `helmsman_esignet.yml`:
+
+1. **Auto-trigger `helmsman_signup.yml`** — after a successful eSignet standalone deployment (`profile=esignet-standalone`), the `workflow-caller` job calls the GitHub Actions API to dispatch the signup workflow automatically. This requires `Actions: Read and write` on the PAT. Without it, the signup workflow will never be triggered even if eSignet deploys successfully.
+2. **Repository operations during deploy** — used as `GH_TOKEN` override for authenticated GitHub API calls within the deploy job.
+
+### How to Generate GH_INFRA_PAT
+
+1. **Go to GitHub Settings**
+   - Click your profile picture (top right) → **Settings**
+   - Scroll down and click **Developer settings** (bottom of left sidebar)
+   - Click **Personal access tokens** → **Fine-grained tokens**
+   - Click **Generate new token**
+
+2. **Configure Token Settings**
+   - **Token name**: `GH_INFRA_PAT`
+   - **Expiration**: Set as needed (e.g., 90 days)
+   - **Resource owner**: Select your organization or user account (e.g., `mosip`)
+   - **Repository access**: Select **Only select repositories** → choose your infra repository (e.g., `mosip/infra`)
+
+3. **Set Permissions**
+
+   Under **Repository permissions**, set exactly these:
+
+   | Permission | Level | Why |
+   |---|---|---|
+   | **Contents** | Read and write | Push/pull operations — Read-only causes 403 on push |
+   | **Metadata** | Read-only | Required by GitHub (auto-selected) |
+   | **Actions** | Read and write | **Critical** — dispatches `helmsman_signup.yml` via GitHub API after eSignet deploy |
+   | **Environments** | Read and write | Read/write environment configuration |
+   | **Variables** | Read and write | Read/write environment variables |
+
+   > **No Secrets permission needed** — intentionally excluded to follow least-privilege principle.
+
+4. **Generate and Save**
+   - Click **Generate token**
+   - **Copy the token immediately** — it is only shown once
+   - Save it securely in a password manager
+
+### Where to Use It
+Add as **Repository Secret** in GitHub:
+- **Name**: `GH_INFRA_PAT`
+- **Value**: `github_pat_...` (your generated token)
+
+### Common Pitfalls
+- ❌ **`Actions: Read-only`** — workflow dispatch requires write; signup auto-trigger will silently fail even though eSignet deployed successfully
+- ❌ **`Contents: Read-only`** — causes 403 error on push operations during deploy
+- ❌ Adding **Secrets** permission — not needed, violates least-privilege
+- ❌ Selecting **All repositories** instead of only the infra repository
+- ❌ Not saving the token immediately after generation — shown only once
+
+---
+
+## 5. WireGuard VPN Configuration
 
 ### What is it?
 WireGuard is a modern VPN that creates secure connections to your private infrastructure.
@@ -367,7 +427,7 @@ Add as **Environment Secrets** in GitHub (not repository secrets):
 
 ---
 
-## 5. Kubernetes Config (KUBECONFIG)
+## 6. Kubernetes Config (KUBECONFIG)
 
 ### What is it?
 KUBECONFIG is a configuration file that contains credentials and connection details for your Kubernetes cluster.
@@ -471,7 +531,7 @@ users:
 
 ---
 
-## 6. reCAPTCHA Keys
+## 7. reCAPTCHA Keys
 
 ### What is it?
 reCAPTCHA is Google's service that protects websites from bots and spam by verifying users are human.
@@ -557,7 +617,7 @@ hooks:
 
 ---
 
-## 7. How to Add Secrets to GitHub
+## 8. How to Add Secrets to GitHub
 
 ### Understanding Secret Types
 
@@ -591,6 +651,7 @@ hooks:
  - `GPG_PASSPHRASE`
  - `AWS_ACCESS_KEY_ID`
  - `AWS_SECRET_ACCESS_KEY`
+ - `GH_INFRA_PAT`
  - `mosip-aws` (or your SSH key name)
 
 ### Step-by-Step: Adding Environment Secrets
@@ -626,6 +687,7 @@ Repository Structure:
 │ ├── GPG_PASSPHRASE
 │ ├── AWS_ACCESS_KEY_ID
 │ ├── AWS_SECRET_ACCESS_KEY
+│ ├── GH_INFRA_PAT
 │ └── mosip-aws (SSH private key)
 │
 └── Environments
@@ -662,6 +724,7 @@ Use this checklist to ensure you've generated and configured all required secret
 - [ ] GPG Passphrase generated and added
 - [ ] AWS Access Key ID obtained and added
 - [ ] AWS Secret Access Key obtained and added
+- [ ] GitHub PAT (GH_INFRA_PAT) generated with correct permissions and added
 
 ### Infrastructure Deployment
 - [ ] Terraform base-infra deployed successfully


### PR DESCRIPTION
## Summary
- `demo`'s copy of `docs/SECRET_GENERATION_GUIDE.md` was missing the "GitHub Personal Access Token (GH_INFRA_PAT)" section that exists on `develop` (used for the eSignet → signup workflow auto-trigger and repo operations in `helmsman_esignet.yml`).
- Ports that section over verbatim, along with the cascading TOC/heading renumbering and the corresponding checklist, secrets-list, and directory-tree references later in the doc.
- Diffed against `develop`'s version first to confirm no `demo`-specific content would be lost — the two files are otherwise identical.