### PR TITLE
feat(helmsman): add isolated esignet-standalone-2.0.0 profile

### DIFF
--- a/.github/workflows/helmsman_esignet.yml
+++ b/.github/workflows/helmsman_esignet.yml
@@ -12,6 +12,7 @@ on:
           - mosip-platform-1.2.0.x
           - mosip-platform-1.2.1.x
           - esignet-standalone
+          - esignet-standalone-2.0.0
       mode:
         description: "Choose Helmsman mode: dry-run or apply"
         required: true
@@ -90,7 +91,7 @@ jobs:
           echo "✓ esignet_db_port = $ESIGNET_DB_PORT"
           # mosipid1_domain_name and mosipid2_domain_name are esignet standalone only.
           # Push events always target esignet (path filter); dispatch uses explicit profile input.
-          if [ -z "$PROFILE" ] || [ "$PROFILE" = "esignet-standalone" ]; then
+          if [ -z "$PROFILE" ] || [[ "$PROFILE" == esignet-standalone* ]]; then
             MOSIPID1_DOMAIN="${{ github.event.inputs.mosipid1_domain_name || vars.MOSIPID1_DOMAIN_NAME }}"
             MOSIPID2_DOMAIN="${{ github.event.inputs.mosipid2_domain_name || vars.MOSIPID2_DOMAIN_NAME }}"
             echo "✓ mosipid1_domain_name = $MOSIPID1_DOMAIN (esignet standalone)"
@@ -325,7 +326,7 @@ jobs:
           kubectl cluster-info
 
       - name: Check if mosip-dsf label is completed
-        if: ${{ github.event.inputs.skip_mosip_dsf_check != 'true' && vars.ESIGNET_STANDALONE_MODE != 'true' && github.event.inputs.profile != 'esignet-standalone' }}
+        if: ${{ github.event.inputs.skip_mosip_dsf_check != 'true' && vars.ESIGNET_STANDALONE_MODE != 'true' && !startsWith(github.event.inputs.profile, 'esignet-standalone') }}
         run: |
           STATUS=$(kubectl get namespace default -o jsonpath='{.metadata.labels.mosip-dsf}' 2>/dev/null || echo "")
           if [[ "$STATUS" != "completed" ]]; then
@@ -380,7 +381,7 @@ jobs:
           fi
           
           # Per-namespace captcha secrets — only required for esignet standalone profile
-          if [ "$PROFILE" = "esignet-standalone" ]; then
+          if [[ "$PROFILE" == esignet-standalone* ]]; then
             echo "--- Validating esignet standalone mosipid1 captcha secrets ---"
             for var in ESIGNET_MOSIPID1_CAPTCHA_SITE_KEY ESIGNET_MOSIPID1_CAPTCHA_SECRET_KEY \
                        ESIGNET_SUNBIRD_CAPTCHA_SITE_KEY ESIGNET_SUNBIRD_CAPTCHA_SECRET_KEY; do
@@ -431,7 +432,7 @@ jobs:
             echo "  - MOCK_RELYING_PARTY_JWE_PRIVATE_KEY (base64 encoded PEM)"
             echo "  - ESIGNET_CAPTCHA_SITE_KEY (reCAPTCHA site key - plain text)"
             echo "  - ESIGNET_CAPTCHA_SECRET_KEY (reCAPTCHA secret key - plain text)"
-            if [ "$PROFILE" = "esignet-standalone" ]; then
+            if [[ "$PROFILE" == esignet-standalone* ]]; then
               echo "  - ESIGNET_MOSIPID1_CAPTCHA_SITE_KEY / ESIGNET_MOSIPID1_CAPTCHA_SECRET_KEY"
               echo "  - ESIGNET_SUNBIRD_CAPTCHA_SITE_KEY / ESIGNET_SUNBIRD_CAPTCHA_SECRET_KEY"
               echo "  - MOSIPID1_POSTGRES_PASSWORD / MOSIPID1_KEYCLOAK_ADMIN_PASSWORD"
@@ -472,7 +473,7 @@ jobs:
           fi
 
       - name: Get MinIO root password
-        if: ${{ env.PROFILE == 'esignet-standalone' }}
+        if: ${{ startsWith(env.PROFILE, 'esignet-standalone') }}
         run: |
           MINIO_ROOT_PASSWORD=$(kubectl -n minio get secret minio -o jsonpath='{.data.root-password}' | base64 -d)
           if [ -n "$MINIO_ROOT_PASSWORD" ]; then
@@ -579,9 +580,14 @@ jobs:
           # they read the new PIN but the PVC token has the old one → CKR_PIN_INCORRECT.
           # Fix: skip softhsm upgrade on re-runs so the PIN in the secret never changes.
           SKIP_RELEASES_ARG=""
-          if [ "$PROFILE" = "esignet-standalone" ]; then
+          if [[ "$PROFILE" == esignet-standalone* ]]; then
+            case "$PROFILE" in
+              esignet-standalone) NS_SUFFIX="" ;;
+              esignet-standalone-2.0.0) NS_SUFFIX="-2-0-0" ;;
+              *) NS_SUFFIX="" ;;
+            esac
             SKIP_RELEASES=""
-            for pair in "esignet-softhsm:esignet-mock" "esignet-softhsm-mosipid1:esignet-mosipid1" "esignet-softhsm-mosipid2:esignet-mosipid2" "esignet-softhsm-sunbird:esignet-sunbird"; do
+            for pair in "esignet-softhsm${NS_SUFFIX}:esignet-mock${NS_SUFFIX}" "esignet-softhsm-mosipid1${NS_SUFFIX}:esignet-mosipid1${NS_SUFFIX}" "esignet-softhsm-mosipid2${NS_SUFFIX}:esignet-mosipid2${NS_SUFFIX}" "esignet-softhsm-sunbird${NS_SUFFIX}:esignet-sunbird${NS_SUFFIX}"; do
               release="${pair%%:*}"
               ns="${pair##*:}"
               if helm status "$release" -n "$ns" &>/dev/null; then

--- a/.github/workflows/helmsman_signup.yml
+++ b/.github/workflows/helmsman_signup.yml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - esignet-standalone
+          - esignet-standalone-2.0.0
           - mosip-platform-1.2.0.x
           - mosip-platform-1.2.1.x
       mode:

--- a/.github/workflows/helmsman_testrigs.yml
+++ b/.github/workflows/helmsman_testrigs.yml
@@ -12,6 +12,7 @@ on:
           - mosip-platform-1.2.0.x
           - mosip-platform-1.2.1.x
           - esignet-standalone
+          - esignet-standalone-2.0.0
       mode:
         description: "Choose Helmsman mode: dry-run or apply"
         required: true
@@ -80,7 +81,7 @@ jobs:
           [ -z "$SLACK_CH" ]        && errors+=("slack_channel_name is empty — set vars.SLACK_CHANNEL_NAME under Environment '${{ github.ref_name }}'")
           [ -z "$DB_PORT" ]         && errors+=("db_port is empty — set vars.DB_PORT under Environment '${{ github.ref_name }}'")
           [ -z "$ESIGNET_DB_PORT" ] && errors+=("esignet_db_port is empty — set vars.ESIGNET_DB_PORT under Environment '${{ github.ref_name }}'")
-          if [ -z "$PROFILE" ] || [ "$PROFILE" = "esignet-standalone" ]; then
+          if [ -z "$PROFILE" ] || [[ "$PROFILE" == esignet-standalone* ]]; then
             MOSIPID1_DOMAIN="${{ github.event.inputs.mosipid1_domain_name || vars.MOSIPID1_DOMAIN_NAME }}"
             MOSIPID2_DOMAIN="${{ github.event.inputs.mosipid2_domain_name || vars.MOSIPID2_DOMAIN_NAME }}"
             [ -z "$MOSIPID1_DOMAIN" ]    && errors+=("mosipid1_domain_name is empty — set vars.MOSIPID1_DOMAIN_NAME under Environment '${{ github.ref_name }}'")
@@ -97,7 +98,7 @@ jobs:
           echo "✓ slack_channel_name = $SLACK_CH"
           echo "✓ db_port            = $DB_PORT"
           echo "✓ esignet_db_port    = $ESIGNET_DB_PORT"
-          if [ -z "$PROFILE" ] || [ "$PROFILE" = "esignet-standalone" ]; then
+          if [ -z "$PROFILE" ] || [[ "$PROFILE" == esignet-standalone* ]]; then
             echo "✓ mosipid1_domain_name    = $MOSIPID1_DOMAIN (esignet profile)"
             echo "✓ mosipid2_domain_name = $MOSIPID2_DOMAIN (esignet profile)"
           fi
@@ -276,7 +277,7 @@ jobs:
           kubectl get nodes
           kubectl cluster-info
       - name: Get MinIO root password (esignet profile)
-        if: env.PROFILE == 'esignet-standalone'
+        if: startsWith(env.PROFILE, 'esignet-standalone')
         run: |
           if kubectl -n minio get secret minio &>/dev/null; then
             MINIO_ROOT_PASSWORD=$(kubectl -n minio get secret minio -o jsonpath='{.data.root-password}' | base64 -d)
@@ -292,7 +293,7 @@ jobs:
           fi
 
       - name: Check if mosip-dsf label is completed
-        if: env.PROFILE != 'esignet-standalone'
+        if: ${{ !startsWith(env.PROFILE, 'esignet-standalone') }}
         run: |
           STATUS=$(kubectl get namespace default -o jsonpath='{.metadata.labels.mosip-dsf}')
           if [[ "$STATUS" != "completed" ]]; then
@@ -301,7 +302,7 @@ jobs:
           fi
 
       - name: Check if esignet-dsf label is completed
-        if: env.PROFILE == 'esignet-standalone'
+        if: startsWith(env.PROFILE, 'esignet-standalone')
         run: |
           STATUS=$(kubectl get namespace default -o jsonpath='{.metadata.labels.esignet-dsf}' 2>/dev/null || echo "")
           if [[ "$STATUS" != "completed" ]]; then

--- a/Helmsman/dsf/esignet-standalone-2.0.0/esignet-dsf.yaml
+++ b/Helmsman/dsf/esignet-standalone-2.0.0/esignet-dsf.yaml
@@ -135,6 +135,7 @@ apps:
     priority: -14
     hooks:
       preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/esignet-preinstall.sh"
+      postInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/captcha-postinstall.sh"
 
   esignet-mosipid1-2-0-0:
     namespace: esignet-mosipid1-2-0-0

--- a/Helmsman/dsf/esignet-standalone-2.0.0/esignet-dsf.yaml
+++ b/Helmsman/dsf/esignet-standalone-2.0.0/esignet-dsf.yaml
@@ -1,0 +1,661 @@
+# =============================================================================
+# eSignet Profile - eSignet Services DSF (Desired State File)
+# =============================================================================
+# This DSF deploys eSignet v1.7.1 services for the standalone eSignet profile.
+#
+# Components (in priority order):
+#   1. Keycloak Init (eSignet-specific clients and roles)
+#   2. eSignet service v1.7.1
+#   3. OIDC UI v1.7.1
+#   4. Mock Identity System (optional, disabled by default)
+#   5. Mock Relying Party Service (optional)
+#   6. Mock Relying Party UI (optional)
+#   7. Partner Onboarder (eSignet + Resident OIDC)
+#   8. Demo OIDC Partner Onboarder
+#
+# Based on eSignet v1.7.1 deploy scripts:
+#   - install-esignet.sh
+#   - initialise-prereq.sh (keycloak-init)
+# =============================================================================
+
+helmDefaults:
+  tillerNamespace: kube-system
+  tillerless: true
+  install: true
+
+helmRepos:
+  bitnami: https://charts.bitnami.com/bitnami
+  mosip: https://mosip.github.io/mosip-helm
+
+namespaces:
+  esignet-mock-2-0-0:
+    protected: false
+  softhsm-2-0-0:
+    protected: false
+  esignet-mosipid1-2-0-0:
+    protected: false
+  esignet-mosipid2-2-0-0:
+    protected: false
+  esignet-sunbird-2-0-0:
+    protected: false           
+
+apps:
+  # ---------------------------------------------------------------------------
+  # SoftHSM for eSignet
+  # ---------------------------------------------------------------------------
+  # Deployed here (not in external-dsf) so esignet-softhsm-share configmap is
+  # available in esignet namespace before eSignet service starts.
+  esignet-softhsm-2-0-0:
+    namespace: esignet-mock-2-0-0
+    enabled: true
+    version: 12.0.1
+    chart: mosip/softhsm
+    valuesFile: "$WORKDIR/utils/softhsm-esignet-values.yaml"
+    timeout: 480
+    priority: -16
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/softhsm-esignet-setup.sh"
+
+  esignet-softhsm-mosipid1-2-0-0:
+    namespace: esignet-mosipid1-2-0-0
+    enabled: true
+    version: 12.0.1
+    chart: mosip/softhsm
+    valuesFile: "$WORKDIR/utils/softhsm-esignet-mosipid1-values.yaml"
+    timeout: 480
+    priority: -16
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/softhsm-esignet-mosipid1-setup.sh"
+
+  esignet-softhsm-mosipid2-2-0-0:
+    namespace: esignet-mosipid2-2-0-0
+    enabled: ${MOSIPID2_ENABLED}
+    version: 12.0.1
+    chart: mosip/softhsm
+    valuesFile: "$WORKDIR/utils/softhsm-esignet-mosipid2-values.yaml"
+    timeout: 480
+    priority: -16
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/softhsm-esignet-mosipid2-setup.sh"
+
+  esignet-softhsm-sunbird-2-0-0:
+    namespace: esignet-sunbird-2-0-0
+    enabled: true
+    version: 12.0.1
+    chart: mosip/softhsm
+    valuesFile: "$WORKDIR/utils/softhsm-esignet-sunbird-values.yaml"
+    timeout: 480
+    priority: -16
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/softhsm-esignet-sunbird-setup.sh"
+
+  esignet-config-server-2-0-0:
+    namespace: esignet-mock-2-0-0
+    enabled: false
+    version: 12.0.1
+    chart: mosip/config-server
+    valuesFile: "$WORKDIR/utils/config-server-esignet-values.yaml"
+    wait: true
+    timeout: 1200
+    priority: -15
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/config-server-esignet-setup.sh"
+      postInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/config-server-esignet-postinstall.sh"
+
+  # ---------------------------------------------------------------------------
+  # eSignet v1.7.1
+  # ---------------------------------------------------------------------------
+  esignet-mock-2-0-0:
+    namespace: esignet-mock-2-0-0
+    enabled: true
+    version: 0.0.1-develop
+    chart: mosip/esignet
+    valuesFile: "$WORKDIR/utils/esignet-plugin-values.yaml"
+    set:
+      image.repository: "mosipqa/esignet-with-plugins"
+      image.tag: "develop"
+      enable_insecure: "false"
+      springConfigNameEnv: ""
+      activeProfileEnv: ""
+      pluginNameEnv: "esignet-mock-plugin.jar"
+      pluginUrlEnv: ""
+      extraEnvVarsCM[0]: "esignet-softhsm-share"
+      #extraEnvVarsCM[1]: "kafka-config"
+      metrics.serviceMonitor.enabled: "false"
+      domainConfig.MOSIP_ESIGNET_HOST: "esignet-2-0-0.${domain_name}"
+      domainConfig.MOSIP_SIGNUP_HOST: "signup-2-0-0.${domain_name}"
+      domainConfig.MOSIP_API_HOST: "api.${domain_name}"
+      domainConfig.MOSIP_IAM_EXTERNAL_HOST: "iam.${domain_name}"
+      domainConfig.MOSIP_API_INTERNAL_HOST: "api-internal.${domain_name}"
+      domainConfig.MOSIP_KAFKA_HOST: "kafka.${domain_name}"
+      domainConfig.MOSIP_POSTGRES_HOST: "postgres.${domain_name}"
+      domainConfig.MOSIP_SMTP_HOST: "smtp-2-0-0.${domain_name}"
+      domainConfig.installation-domain: "${domain_name}"
+    timeout: 600
+    priority: -14
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/esignet-preinstall.sh"
+
+  esignet-mosipid1-2-0-0:
+    namespace: esignet-mosipid1-2-0-0
+    enabled: true
+    version: 0.1.0-develop
+    chart: mosip/esignet
+    valuesFile: "$WORKDIR/utils/esignet-mosipid1-plugin-values.yaml"
+    set:
+      image.repository: "mosipqa/esignet-with-plugins"
+      image.tag: "develop"
+      enable_insecure: "false"
+      springConfigNameEnv: ""
+      activeProfileEnv: ""
+      pluginNameEnv: "mosip-identity-plugin.jar"
+      pluginUrlEnv: ""
+      extraEnvVarsCM[0]: "esignet-softhsm-mosipid1-share"
+      extraEnvVarsCM[1]: "esignet-global"
+      metrics.serviceMonitor.enabled: "false"
+      domainConfig.MOSIP_ESIGNET_HOST: "esignet-mosipid1-2-0-0.${domain_name}"
+      domainConfig.MOSIP_SIGNUP_HOST: "signup-mosipid1-2-0-0.${domain_name}"
+      domainConfig.MOSIP_API_HOST: "api.${domain_name}"
+      domainConfig.MOSIP_IAM_EXTERNAL_HOST: "iam.${domain_name}"
+      domainConfig.MOSIP_API_INTERNAL_HOST: "api-internal.${mosipid1_domain_name}"
+      domainConfig.MOSIP_KAFKA_HOST: "kafka.${domain_name}"
+      domainConfig.MOSIP_POSTGRES_HOST: "postgres.${domain_name}"
+      domainConfig.MOSIP_SMTP_HOST: "smtp-2-0-0.${domain_name}"
+      domainConfig.installation-domain: "${domain_name}"
+      domainConfig.IDA_AUTH_URL: "https://api-internal.${mosipid1_domain_name}"
+      domainConfig.IDA_OTP_URL: "https://api-internal.${mosipid1_domain_name}"
+      domainConfig.IDA_INTERNAL_URL: "https://api-internal.${mosipid1_domain_name}"
+      domainConfig.MOSIP_ESIGNET_AUTHENTICATOR_IDA_CERT_URL: "https://api-internal.${mosipid1_domain_name}/mosip-certs/ida-partner.cer"
+      domainConfig.MOSIP_ESIGNET_AUTHENTICATOR_IDA_AUTH_TOKEN_URL: "https://api-internal.${mosipid1_domain_name}/v1/authmanager/authenticate/clientidsecretkey"
+      domainConfig.MOSIP_ESIGNET_AUTHENTICATOR_IDA_AUDIT_MANAGER_URL: "https://api-internal.${mosipid1_domain_name}/v1/auditmanager/audits"
+      domainConfig.MOSIP_ESIGNET_IDA_AUTH_DOMAIN: "https://api-internal.${mosipid1_domain_name}"
+      domainConfig.MOSIP_ESIGNET_AUTHENTICATOR_IDA_DOMAINURI: "https://esignet-mosipid1-2-0-0.${domain_name}"
+      domainConfig.MOSIP_ESIGNET_DOMAIN_URL: "https://esignet-mosipid1-2-0-0.${domain_name}"
+    timeout: 600
+    priority: -14
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/esignet-mosipid1-preinstall.sh"
+
+  esignet-mosipid2-2-0-0:
+    namespace: esignet-mosipid2-2-0-0
+    enabled: ${MOSIPID2_ENABLED}
+    version: 0.0.1-develop
+    chart: mosip/esignet
+    valuesFile: "$WORKDIR/utils/esignet-mosipid2-plugin-values.yaml"
+    set:
+      image.repository: "mosipqa/esignet-with-plugins"
+      image.tag: "develop"
+      enable_insecure: "false"
+      springConfigNameEnv: ""
+      activeProfileEnv: ""
+      pluginNameEnv: "mosip-identity-plugin.jar"
+      pluginUrlEnv: ""
+      extraEnvVarsCM[0]: "esignet-softhsm-mosipid2-share"
+      extraEnvVarsCM[1]: "esignet-global"
+      metrics.serviceMonitor.enabled: "false"
+      domainConfig.MOSIP_ESIGNET_HOST: "esignet-mosipid2-2-0-0.${domain_name}"
+      domainConfig.MOSIP_SIGNUP_HOST: "signup-mosipid2-2-0-0.${domain_name}"
+      domainConfig.MOSIP_API_HOST: "api.${domain_name}"
+      domainConfig.MOSIP_IAM_EXTERNAL_HOST: "iam.${domain_name}"
+      domainConfig.MOSIP_API_INTERNAL_HOST: "api-internal.${mosipid2_domain_name}"
+      domainConfig.MOSIP_KAFKA_HOST: "kafka.${domain_name}"
+      domainConfig.MOSIP_POSTGRES_HOST: "postgres.${domain_name}"
+      domainConfig.MOSIP_SMTP_HOST: "smtp-2-0-0.${domain_name}"
+      domainConfig.installation-domain: "${domain_name}"
+      domainConfig.IDA_AUTH_URL: "https://api-internal.${mosipid2_domain_name}"
+      domainConfig.IDA_OTP_URL: "https://api-internal.${mosipid2_domain_name}"
+      domainConfig.IDA_INTERNAL_URL: "https://api-internal.${mosipid2_domain_name}"
+      domainConfig.MOSIP_ESIGNET_AUTHENTICATOR_IDA_CERT_URL: "https://api-internal.${mosipid2_domain_name}/mosip-certs/ida-partner.cer"
+      domainConfig.MOSIP_ESIGNET_AUTHENTICATOR_IDA_AUTH_TOKEN_URL: "https://api-internal.${mosipid2_domain_name}/v1/authmanager/authenticate/clientidsecretkey"
+      domainConfig.MOSIP_ESIGNET_AUTHENTICATOR_IDA_AUDIT_MANAGER_URL: "https://api-internal.${mosipid2_domain_name}/v1/auditmanager/audits"
+      domainConfig.MOSIP_ESIGNET_IDA_AUTH_DOMAIN: "https://api-internal.${mosipid2_domain_name}"
+      domainConfig.MOSIP_ESIGNET_AUTHENTICATOR_IDA_DOMAINURI: "https://esignet-mosipid2-2-0-0.${domain_name}"
+      domainConfig.MOSIP_ESIGNET_DOMAIN_URL: "https://esignet-mosipid2-2-0-0.${domain_name}"
+    timeout: 600
+    priority: -14
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/esignet-mosipid2-preinstall.sh"
+
+  esignet-sunbird-2-0-0:
+    namespace: esignet-sunbird-2-0-0
+    enabled: true
+    version: 0.0.1-develop
+    chart: mosip/esignet
+    valuesFile: "$WORKDIR/utils/esignet-sunbird-plugin-values.yaml"
+    set:
+      image.repository: "mosipqa/esignet-with-plugins"
+      image.tag: "develop"
+      enable_insecure: "false"
+      springConfigNameEnv: ""
+      activeProfileEnv: ""
+      pluginNameEnv: "sunbird-rc-plugin.jar"
+      pluginUrlEnv: ""
+      extraEnvVarsCM[0]: "esignet-softhsm-sunbird-share"
+      #extraEnvVarsCM[1]: "kafka-config"
+      metrics.serviceMonitor.enabled: "false"
+      domainConfig.MOSIP_ESIGNET_HOST: "esignet-sunbird-2-0-0.${domain_name}"
+      domainConfig.MOSIP_SIGNUP_HOST: "signup-sunbird-2-0-0.${domain_name}"
+      domainConfig.MOSIP_API_HOST: "api.${domain_name}"
+      domainConfig.MOSIP_IAM_EXTERNAL_HOST: "iam.${domain_name}"
+      domainConfig.MOSIP_API_INTERNAL_HOST: "api-internal.${domain_name}"
+      domainConfig.MOSIP_KAFKA_HOST: "kafka.${domain_name}"
+      domainConfig.MOSIP_POSTGRES_HOST: "postgres.${domain_name}"
+      domainConfig.MOSIP_SMTP_HOST: "smtp-2-0-0.${domain_name}"
+      domainConfig.installation-domain: "${domain_name}"
+      domainConfig.MOSIP_ESIGNET_SUNBIRD_RC_REGISTRY_GET_URL: "https://registry.${mosipid1_domain_name}"
+      domainConfig.MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_REGISTRY_SEARCH_URL: "https://registry.${mosipid1_domain_name}/api/v1/Insurance/search"
+      domainConfig.MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_REGISTRY_GET_URL: "https://registry.${mosipid1_domain_name}/api/v1/Insurance/"
+    timeout: 600
+    priority: -14
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/esignet-sunbird-preinstall.sh"
+
+  # ---------------------------------------------------------------------------
+  # OIDC UI v1.7.1
+  # ---------------------------------------------------------------------------
+  oidc-ui-2-0-0:
+    namespace: esignet-mock-2-0-0
+    enabled: true
+    version: 0.0.1-develop
+    chart: mosip/oidc-ui
+    set:
+      image.repository: "mosipqa/oidc-ui"
+      image.tag: "develop"    
+      istio.hosts[0]: "esignet-2-0-0.${domain_name}"
+      oidc_ui.oidc_service_host: "esignet-mock-2-0-0.esignet-mock-2-0-0"
+      oidc_ui.configmaps.oidc-ui.REACT_APP_API_BASE_URL: "http://esignet-mock-2-0-0.esignet-mock-2-0-0/v1/esignet"
+      oidc_ui.configmaps.oidc-ui.REACT_APP_SBI_DOMAIN_URI: "http://esignet-mock-2-0-0.esignet-mock-2-0-0"
+    timeout: 1200
+    priority: -13
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/oidc-ui-preinstall.sh"
+
+  oidc-ui-mosipid1-2-0-0:
+    namespace: esignet-mosipid1-2-0-0
+    enabled: true
+    version: 0.1.0-develop
+    chart: mosip/oidc-ui
+    set:
+      image.repository: "mosipqa/oidc-ui"
+      image.tag: "develop"
+      istio.hosts[0]: "esignet-mosipid1-2-0-0.${domain_name}"
+      oidc_ui.oidc_service_host: "esignet-mosipid1-2-0-0.esignet-mosipid1-2-0-0"
+      oidc_ui.configmaps.oidc-ui.REACT_APP_API_BASE_URL: "http://esignet-mosipid1-2-0-0.esignet-mosipid1-2-0-0/v1/esignet"
+      oidc_ui.configmaps.oidc-ui.REACT_APP_SBI_DOMAIN_URI: "http://esignet-mosipid1-2-0-0.esignet-mosipid1-2-0-0"
+    timeout: 1200
+    priority: -13
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/oidc-ui-mosipid1-preinstall.sh"
+
+  oidc-ui-mosipid2-2-0-0:
+    namespace: esignet-mosipid2-2-0-0
+    enabled: ${MOSIPID2_ENABLED}
+    version: 0.0.1-develop
+    chart: mosip/oidc-ui
+    set:
+      image.repository: "mosipqa/oidc-ui"
+      image.tag: "develop"
+      istio.hosts[0]: "esignet-mosipid2-2-0-0.${domain_name}"
+      oidc_ui.oidc_service_host: "esignet-mosipid2-2-0-0.esignet-mosipid2-2-0-0"
+      oidc_ui.configmaps.oidc-ui.REACT_APP_API_BASE_URL: "http://esignet-mosipid2-2-0-0.esignet-mosipid2-2-0-0/v1/esignet"
+      oidc_ui.configmaps.oidc-ui.REACT_APP_SBI_DOMAIN_URI: "http://esignet-mosipid2-2-0-0.esignet-mosipid2-2-0-0"
+    timeout: 1200
+    priority: -13
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/oidc-ui-mosipid2-preinstall.sh"
+
+  oidc-ui-sunbird-2-0-0:
+    namespace: esignet-sunbird-2-0-0
+    enabled: true
+    version: 0.0.1-develop
+    chart: mosip/oidc-ui
+    set:
+      image.repository: "mosipqa/oidc-ui"
+      image.tag: "1.8.x"
+      istio.hosts[0]: "esignet-sunbird-2-0-0.${domain_name}"
+      oidc_ui.oidc_service_host: "esignet-sunbird-2-0-0.esignet-sunbird-2-0-0"
+      oidc_ui.configmaps.oidc-ui.REACT_APP_API_BASE_URL: "http://esignet-sunbird-2-0-0.esignet-sunbird-2-0-0/v1/esignet"
+      oidc_ui.configmaps.oidc-ui.REACT_APP_SBI_DOMAIN_URI: "http://esignet-sunbird-2-0-0.esignet-sunbird-2-0-0"
+    timeout: 1200
+    priority: -13
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/oidc-ui-sunbird-preinstall.sh"
+
+  # ---------------------------------------------------------------------------
+  # Mock Identity System (Optional)
+  # ---------------------------------------------------------------------------
+  # Enable for testing with mock identity data.
+  softhsm-mock-identity-system-2-0-0:
+    namespace: softhsm-2-0-0
+    enabled: true
+    version: 12.0.1
+    chart: mosip/softhsm
+    valuesFile: "$WORKDIR/utils/softhsm-mock-identity-system-values.yaml"
+    wait: true
+    timeout: 480
+    priority: -12
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/softhsm-mock-identity-system-preinstall.sh"
+      postInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/softhsm-mock-identity-system-postinstall.sh"
+      preUpgrade: "$WORKDIR/hooks/esignet-standalone-2.0.0/softhsm-mock-identity-system-preinstall.sh"
+      postUpgrade: "$WORKDIR/hooks/esignet-standalone-2.0.0/softhsm-mock-identity-system-postinstall.sh"
+
+  mock-identity-system-2-0-0:
+    namespace: esignet-mock-2-0-0
+    enabled: true
+    version: 0.0.1-develop
+    chart: mosip/mock-identity-system
+    valuesFile: "$WORKDIR/utils/mock-identity-values.yaml"
+    set:
+      image.repository: "mosipqa/mock-identity-system"
+      image.tag: "develop"
+      enable_insecure: "false"
+      extraEnvVarsCM[0]: "softhsm-mock-identity-system-share"
+      domainConfig.MOSIP_ESIGNET_HOST: "esignet-2-0-0.${domain_name}"
+      domainConfig.MOSIP_SIGNUP_HOST: "signup-2-0-0.${domain_name}"
+      domainConfig.MOSIP_API_HOST: "api.${domain_name}"
+      domainConfig.MOSIP_IAM_EXTERNAL_HOST: "iam.${domain_name}"
+      domainConfig.MOSIP_API_INTERNAL_HOST: "api-internal.${domain_name}"
+      domainConfig.MOSIP_KAFKA_HOST: "kafka.${domain_name}"
+      domainConfig.MOSIP_POSTGRES_HOST: "postgres.${domain_name}"
+      domainConfig.MOSIP_SMTP_HOST: "smtp-2-0-0.${domain_name}"
+      domainConfig.installation-domain: "${domain_name}"
+      domainConfig.MOSIP_MOCK_IDA_IDENTITY_SCHEMA_URL: "https://raw.githubusercontent.com/prathmeshj12/addidentityschema_testing/refs/heads/main/email-signup-schema-testing.json"
+      domainConfig.MOSIP_MOCK_UI_SPEC_SCHEMA_URL: "https://raw.githubusercontent.com/prathmeshj12/addidentityschema_testing/refs/heads/main/ui_spec_reset_password_phone.json"
+    timeout: 480
+    priority: -11
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/mock-identity-system-preinstall.sh"
+
+  # ---------------------------------------------------------------------------
+  # Mock Relying Party (Optional)
+  # ---------------------------------------------------------------------------
+  mock-relying-party-service-2-0-0:
+    namespace: esignet-mock-2-0-0
+    enabled: true
+    version: 0.0.1-develop
+    chart: mosip/mock-relying-party-service
+    set:
+      mock_relying_party_service.ESIGNET_SERVICE_URL: "http://esignet-mock-2-0-0.esignet-mock-2-0-0/v1/esignet"
+      mock_relying_party_service.ESIGNET_AUD_URL: "https://esignet-2-0-0.${domain_name}/v1/esignet/oauth/v2/token"
+      enable_insecure: "false"
+      domainConfig.MOSIP_API_INTERNAL_HOST: "api-internal.${domain_name}"
+    timeout: 480
+    priority: -10
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/mock-relying-party-service-preinstall.sh"
+
+  mock-relying-party-service-mosipid1-2-0-0:
+    namespace: esignet-mosipid1-2-0-0
+    enabled: true
+    version: 0.0.1-develop
+    chart: mosip/mock-relying-party-service
+    set:
+      mock_relying_party_service.ESIGNET_SERVICE_URL: "http://esignet-mosipid1-2-0-0.esignet-mosipid1-2-0-0/v1/esignet"
+      mock_relying_party_service.ESIGNET_AUD_URL: "https://esignet-mosipid1-2-0-0.${domain_name}/v1/esignet/oauth/v2/token"
+      enable_insecure: "false"
+      domainConfig.MOSIP_API_INTERNAL_HOST: "api-internal.${domain_name}"
+    timeout: 480
+    priority: -10
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/mock-relying-party-service-mosipid1-preinstall.sh"
+
+  mock-relying-party-service-mosipid2-2-0-0:
+    namespace: esignet-mosipid2-2-0-0
+    enabled: ${MOSIPID2_ENABLED}
+    version: 0.0.1-develop
+    chart: mosip/mock-relying-party-service
+    set:
+      mock_relying_party_service.ESIGNET_SERVICE_URL: "http://esignet-mosipid2-2-0-0.esignet-mosipid2-2-0-0/v1/esignet"
+      mock_relying_party_service.ESIGNET_AUD_URL: "https://esignet-mosipid2-2-0-0.${domain_name}/v1/esignet/oauth/v2/token"
+      enable_insecure: "false"
+      domainConfig.MOSIP_API_INTERNAL_HOST: "api-internal.${domain_name}"
+    timeout: 480
+    priority: -10
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/mock-relying-party-service-mosipid2-preinstall.sh"
+
+  mock-relying-party-service-sunbird-2-0-0:
+    namespace: esignet-sunbird-2-0-0
+    enabled: true
+    version: 0.0.1-develop
+    chart: mosip/mock-relying-party-service
+    set:
+      mock_relying_party_service.ESIGNET_SERVICE_URL: "http://esignet-sunbird-2-0-0.esignet-sunbird-2-0-0/v1/esignet"
+      mock_relying_party_service.ESIGNET_AUD_URL: "https://esignet-sunbird-2-0-0.${domain_name}/v1/esignet/oauth/v2/token"
+      enable_insecure: "false"
+      domainConfig.MOSIP_API_INTERNAL_HOST: "api-internal.${domain_name}"
+    timeout: 480
+    priority: -10
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/mock-relying-party-service-sunbird-preinstall.sh"
+
+  mock-relying-party-ui-2-0-0:
+    namespace: esignet-mock-2-0-0
+    enabled: true
+    version: 0.0.1-develop
+    chart: mosip/mock-relying-party-ui
+    set:
+      mock_relying_party_ui.mock_relying_party_ui_service_host: "healthservices-2-0-0.${domain_name}"
+      mock_relying_party_ui.MOCK_RELYING_PARTY_SERVICE_INTERNAL_URL: "http://mock-relying-party-service-2-0-0.esignet-mock-2-0-0"
+      mock_relying_party_ui.ESIGNET_UI_BASE_URL: "https://esignet-2-0-0.${domain_name}"
+      mock_relying_party_ui.MOCK_RELYING_PARTY_SERVER_URL: "https://healthservices-2-0-0.${domain_name}/mock-relying-party-service"
+      mock_relying_party_ui.REDIRECT_URI: "https://healthservices-2-0-0.${domain_name}/userprofile"
+      mock_relying_party_ui.REDIRECT_URI_REGISTRATION: "https://healthservices-2-0-0.${domain_name}/registration"
+      mock_relying_party_ui.SIGN_IN_BUTTON_PLUGIN_URL: "https://esignet-2-0-0.${domain_name}/plugins/sign-in-button-plugin.js"
+      istio.hosts[0]: "healthservices-2-0-0.${domain_name}"
+    wait: true
+    timeout: 480
+    priority: -9
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/mock-relying-party-ui-preinstall.sh"
+
+  mock-relying-party-ui-mosipid1-2-0-0:
+    namespace: esignet-mosipid1-2-0-0
+    enabled: true
+    version: 0.0.1-develop
+    chart: mosip/mock-relying-party-ui
+    set:
+      mock_relying_party_ui.mock_relying_party_ui_service_host: "healthservices-mosipid1-2-0-0.${domain_name}"
+      mock_relying_party_ui.MOCK_RELYING_PARTY_SERVICE_INTERNAL_URL: "http://mock-relying-party-service-mosipid1-2-0-0.esignet-mosipid1-2-0-0"
+      mock_relying_party_ui.ESIGNET_UI_BASE_URL: "https://esignet-mosipid1-2-0-0.${domain_name}"
+      mock_relying_party_ui.MOCK_RELYING_PARTY_SERVER_URL: "https://healthservices-mosipid1-2-0-0.${domain_name}/mock-relying-party-service"
+      mock_relying_party_ui.REDIRECT_URI: "https://healthservices-mosipid1-2-0-0.${domain_name}/userprofile"
+      mock_relying_party_ui.REDIRECT_URI_REGISTRATION: "https://healthservices-mosipid1-2-0-0.${domain_name}/registration"
+      mock_relying_party_ui.SIGN_IN_BUTTON_PLUGIN_URL: "https://esignet-mosipid1-2-0-0.${domain_name}/plugins/sign-in-button-plugin.js"
+      istio.hosts[0]: "healthservices-mosipid1-2-0-0.${domain_name}"
+    wait: true
+    timeout: 480
+    priority: -9
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/mock-relying-party-ui-mosipid1-preinstall.sh"
+
+  mock-relying-party-ui-mosipid2-2-0-0:
+    namespace: esignet-mosipid2-2-0-0
+    enabled: ${MOSIPID2_ENABLED}
+    version: 0.0.1-develop
+    chart: mosip/mock-relying-party-ui
+    set:
+      mock_relying_party_ui.mock_relying_party_ui_service_host: "healthservices-mosipid2-2-0-0.${domain_name}"
+      mock_relying_party_ui.MOCK_RELYING_PARTY_SERVICE_INTERNAL_URL: "http://mock-relying-party-service-mosipid2-2-0-0.esignet-mosipid2-2-0-0"
+      mock_relying_party_ui.ESIGNET_UI_BASE_URL: "https://esignet-mosipid2-2-0-0.${domain_name}"
+      mock_relying_party_ui.MOCK_RELYING_PARTY_SERVER_URL: "https://healthservices-mosipid2-2-0-0.${domain_name}/mock-relying-party-service"
+      mock_relying_party_ui.REDIRECT_URI: "https://healthservices-mosipid2-2-0-0.${domain_name}/userprofile"
+      mock_relying_party_ui.REDIRECT_URI_REGISTRATION: "https://healthservices-mosipid2-2-0-0.${domain_name}/registration"
+      mock_relying_party_ui.SIGN_IN_BUTTON_PLUGIN_URL: "https://esignet-mosipid2-2-0-0.${domain_name}/plugins/sign-in-button-plugin.js"
+      istio.hosts[0]: "healthservices-mosipid2-2-0-0.${domain_name}"
+    wait: true
+    timeout: 480
+    priority: -9
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/mock-relying-party-ui-mosipid2-preinstall.sh"
+
+  mock-relying-party-ui-sunbird-2-0-0:
+    namespace: esignet-sunbird-2-0-0
+    enabled: true
+    version: 0.0.1-develop
+    chart: mosip/mock-relying-party-ui
+    set:
+      mock_relying_party_ui.mock_relying_party_ui_service_host: "healthservices-sunbird-2-0-0.${domain_name}"
+      mock_relying_party_ui.MOCK_RELYING_PARTY_SERVICE_INTERNAL_URL: "http://mock-relying-party-service-sunbird-2-0-0.esignet-sunbird-2-0-0"
+      mock_relying_party_ui.ESIGNET_UI_BASE_URL: "https://esignet-sunbird-2-0-0.${domain_name}"
+      mock_relying_party_ui.MOCK_RELYING_PARTY_SERVER_URL: "https://healthservices-sunbird-2-0-0.${domain_name}/mock-relying-party-service"
+      mock_relying_party_ui.REDIRECT_URI: "https://healthservices-sunbird-2-0-0.${domain_name}/userprofile"
+      mock_relying_party_ui.REDIRECT_URI_REGISTRATION: "https://healthservices-sunbird-2-0-0.${domain_name}/registration"
+      mock_relying_party_ui.SIGN_IN_BUTTON_PLUGIN_URL: "https://esignet-sunbird-2-0-0.${domain_name}/plugins/sign-in-button-plugin.js"
+      istio.hosts[0]: "healthservices-sunbird-2-0-0.${domain_name}"
+    wait: true
+    timeout: 480
+    priority: -9
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/mock-relying-party-ui-sunbird-preinstall.sh"
+
+  pms-partner-mosipid1-2-0-0:
+    namespace: esignet-mosipid1-2-0-0
+    enabled: false
+    version: 12.2.3
+    chart: mosip/pms-partner
+    set:
+      # image.repository: "mosipid/partner-management-service"
+      # image.tag: "1.2.2.3"
+      istio.gateways[0]: "pms-partner-mosipid1-gateway"
+      istio.corsPolicy.allowOrigins[0].prefix: "https://pms-mosipid1-2-0-0.${domain_name}"
+      extraEnvVarsCM[0]: "esignet-global"
+      extraEnvVarsCM[1]: "esignet-config-server-share"
+    priority: -9
+    timeout: 1200
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/pms-partner-mosipid1-preinstall.sh"
+
+  pms-policy-mosipid1-2-0-0:
+    namespace: esignet-mosipid1-2-0-0
+    enabled: false
+    version: 12.2.3
+    chart: mosip/pms-policy
+    set:
+      # image.repository: "mosipid/policy-management-service"
+      # image.tag: "1.2.2.2"
+      istio.gateways[0]: "pms-partner-mosipid1-gateway"
+      istio.corsPolicy.allowOrigins[0].prefix: "https://pms-mosipid1-2-0-0.${domain_name}"
+      extraEnvVarsCM[0]: "esignet-global"
+      extraEnvVarsCM[1]: "esignet-config-server-share"
+    priority: -9
+    timeout: 1200
+
+  pms-partner-mosipid2-2-0-0:
+    namespace: esignet-mosipid2-2-0-0
+    enabled: false
+    version: 12.2.3
+    chart: mosip/pms-partner
+    set:
+      # image.repository: "mosipid/partner-management-service"
+      # image.tag: "1.2.2.3"
+      istio.gateways[0]: "pms-partner-mosipid2-gateway"
+      istio.corsPolicy.allowOrigins[0].prefix: "https://pms-mosipid2-2-0-0.${domain_name}"
+      extraEnvVarsCM[0]: "esignet-global"
+      extraEnvVarsCM[1]: "esignet-config-server-share"
+    priority: -9
+    timeout: 1200
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/pms-partner-mosipid2-preinstall.sh"
+
+  pms-policy-mosipid2-2-0-0:
+    namespace: esignet-mosipid2-2-0-0
+    enabled: false
+    version: 12.2.3
+    chart: mosip/pms-policy
+    set:
+      # image.repository: "mosipid/policy-management-service"
+      # image.tag: "1.2.2.2"
+      istio.gateways[0]: "pms-partner-mosipid2-gateway"
+      extraEnvVarsCM[0]: "esignet-global"
+      extraEnvVarsCM[1]: "esignet-config-server-share"
+      istio.corsPolicy.allowOrigins[0].prefix: "https://pms-mosipid2-2-0-0.${domain_name}"
+    priority: -9
+    timeout: 1200     
+
+  # ---------------------------------------------------------------------------
+  # Partner Onboarders
+  # ---------------------------------------------------------------------------
+  # Two onboarders for eSignet standalone — enable the one matching your plugin:
+  #   esignet-mock-rp-onboarder: for mock plugin (plugin 1) and sunbird-rc (plugin 3)
+  #   esignet-misp-onboarder:    for mosip-identity-plugin (plugin 2) only
+
+  # eSignet MISP Partner Onboarder
+  # Onboards the eSignet MISP client — only needed with mosip-identity-plugin (plugin 2).
+  # Runs FIRST so the MISP license key is written before mock-rp-onboarder starts.
+  # After completion, restarts the esignet deployment to pick up the new MISP license key.
+  esignet-misp-onboarder-2-0-0:
+    namespace: esignet-mock-2-0-0
+    enabled: false
+    version: 0.0.1-develop
+    chart: mosip/partner-onboarder
+    set:
+      onboarding.modules[0].name: "esignet"
+      onboarding.modules[0].enabled: "true"
+      onboarding.configmaps.s3.s3-host: "http://minio.minio:9000"
+      onboarding.configmaps.s3.s3-user-key: "admin"
+      onboarding.configmaps.s3.s3-region: ""
+      onboarding.configmaps.s3.s3-bucket-name: "onboarder"
+      onboarding.secrets.s3.s3-user-secret: "${MINIO_ROOT_PASSWORD}"
+      onboarding.configmaps.onboarder-namespace.ns_esignet: "esignet-mock-2-0-0"
+      onboarding.variables.push_reports_to_s3: "true"
+      onboarding.variables.mosipid: "false"
+      extraEnvVarsCM[0]: "keycloak-env-vars"
+      extraEnvVarsCM[1]: "keycloak-host"
+      extraEnvVarsSecret[0]: "keycloak"
+      extraEnvVarsSecret[1]: "keycloak-client-secrets"
+      domainConfig.mosip-api-internal-host: "api-internal.${domain_name}"
+      domainConfig.mosip-api-host: "api.${domain_name}"
+      domainConfig.mosip-esignet-host: "esignet-2-0-0.${domain_name}"
+      domainConfig.mosip-esignet-insurance-host: "esignet-insurance.${domain_name}"
+      domainConfig.mosip-resident-host: "resident.${domain_name}"
+      domainConfig.installation-domain: "${domain_name}"
+    wait: true
+    waitForJobs: true
+    timeout: 600
+    priority: -6
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/esignet-misp-onboarder-preinstall.sh"
+      preUpgrade: "$WORKDIR/hooks/esignet-standalone-2.0.0/esignet-misp-onboarder-preinstall.sh"
+      postInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/esignet-misp-onboarder-postinstall.sh"
+      postUpgrade: "$WORKDIR/hooks/esignet-standalone-2.0.0/esignet-misp-onboarder-postinstall.sh"
+
+  # Mock RP OIDC Partner Onboarder
+  # Onboards the mock relying party as an OIDC client.
+  # Enable for plugin 1 (mock) or plugin 3 (sunbird-rc). Set mosipid: "true" for mosip-identity-plugin.
+  esignet-mock-rp-onboarder-2-0-0:
+    namespace: esignet-mock-2-0-0
+    enabled: true
+    version: 0.0.1-develop
+    chart: mosip/partner-onboarder
+    set:
+      image.repository: "mosipid/partner-onboarder"
+      image.tag: "1.3.0-beta.1"
+      onboarding.modules[0].name: "mock-rp-oidc"
+      onboarding.modules[0].enabled: "true"
+      onboarding.configmaps.s3.s3-host: "http://minio.minio:9000"
+      onboarding.configmaps.s3.s3-user-key: "admin"
+      onboarding.configmaps.s3.s3-region: ""
+      onboarding.secrets.s3.s3-user-secret: "${MINIO_ROOT_PASSWORD}"
+      onboarding.configmaps.s3.s3-bucket-name: "onboarder"
+      onboarding.configmaps.onboarder-namespace.ns_esignet: "esignet-mock-2-0-0"
+      onboarding.variables.mosipid: "false"
+      onboarding.variables.push_reports_to_s3: "true"
+      extraEnvVarsCM[0]: "keycloak-env-vars"
+      extraEnvVarsCM[1]: "keycloak-host"
+      domainConfig.mosip-api-internal-host: "api-internal.${domain_name}"
+      domainConfig.mosip-api-host: "api.${domain_name}"
+      domainConfig.mosip-esignet-host: "esignet-2-0-0.${domain_name}"
+      domainConfig.mosip-esignet-insurance-host: "esignet-insurance.${domain_name}"
+      domainConfig.mosip-resident-host: "resident.${domain_name}"
+      domainConfig.installation-domain: "${domain_name}"
+    wait: true
+    waitForJobs: true
+    timeout: 600
+    priority: -5
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/esignet-mock-rp-onboarder-preinstall.sh"
+      preUpgrade: "$WORKDIR/hooks/esignet-standalone-2.0.0/esignet-mock-rp-onboarder-preinstall.sh"
+      postInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/esignet-mock-rp-onboarder-postinstall.sh"
+      postUpgrade: "$WORKDIR/hooks/esignet-standalone-2.0.0/esignet-mock-rp-onboarder-postinstall.sh"

--- a/Helmsman/dsf/esignet-standalone-2.0.0/signup-dsf.yaml
+++ b/Helmsman/dsf/esignet-standalone-2.0.0/signup-dsf.yaml
@@ -1,0 +1,185 @@
+# =============================================================================
+# eSignet Profile - Signup Services DSF (Desired State File)
+# =============================================================================
+# This DSF deploys signup-service and its dependencies on top of the
+# standalone eSignet profile. All apps are disabled by default — enable as
+# needed alongside external-dsf.yaml (which provides postgres-init-signup).
+#
+# Prerequisites (from external-dsf.yaml):
+#   - postgres-init-signup enabled (mosip_audit, mosip_kernel, mosip_otp)
+#   - Redis, Kafka, Keycloak + keycloak-postinstall (keycloak-client-secrets)
+#   - Captcha (for signup captcha validation)
+#
+# Components (in priority order):
+#   1. Signup Keycloak Init  — mosip-signup-client roles and client secret
+#   2. Kernel services       — authmanager, auditmanager, otpmanager, notifier
+#   3. Mock SMTP             — for dev/test email/SMS (optional)
+#   4. Signup service        — signup-service with esignet-mock-plugin.jar
+#   5. Signup UI             — signup-ui
+#
+# Based on eSignet signup deploy scripts:
+#   - deploy/prereq.sh
+#   - deploy/keycloak/keycloak-init.sh
+#   - deploy/kernel/install.sh
+#   - deploy/mock-smtp/install.sh
+#   - deploy/signup-with-plugins/signup-with-mock-plugin/install.sh
+#   - deploy/signup-ui/install.sh
+# =============================================================================
+
+helmDefaults:
+  tillerNamespace: kube-system
+  tillerless: true
+  install: true
+
+helmRepos:
+  mosip: https://mosip.github.io/mosip-helm
+
+namespaces:
+  signup-2-0-0:
+    protected: false
+  kernel-2-0-0:
+    protected: false
+  mock-smtp-2-0-0:
+    protected: false
+
+apps:
+  # ---------------------------------------------------------------------------
+  # Signup Keycloak Init
+  # ---------------------------------------------------------------------------
+  # Creates mosip-signup-client with required roles in Keycloak.
+  # Propagates mosip_signup_client_secret between keycloak and signup namespaces.
+  signup-keycloak-init-2-0-0:
+    namespace: signup-2-0-0
+    enabled: false
+    version: 12.0.2
+    chart: mosip/keycloak-init
+    valuesFile: "$WORKDIR/utils/keycloak-signup-init-values.yaml"
+    set:
+      keycloakInternalHost: "keycloak.keycloak"
+      keycloakExternalHost: "iam.${domain_name}"
+    wait: true
+    waitForJobs: true
+    timeout: 300
+    priority: -10
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/signup-keycloak-init-preinstall.sh"
+      preUpgrade: "$WORKDIR/hooks/esignet-standalone-2.0.0/signup-keycloak-init-preinstall.sh"
+      postInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/signup-keycloak-init-postinstall.sh"
+      postUpgrade: "$WORKDIR/hooks/esignet-standalone-2.0.0/signup-keycloak-init-postinstall.sh"
+
+  # ---------------------------------------------------------------------------
+  # Kernel Services
+  # ---------------------------------------------------------------------------
+  # Required for audit logging (auditmanager), OTP generation (otpmanager),
+  # auth token validation (authmanager), and email/SMS dispatch (notifier).
+  # kernel-preinstall.sh creates kernel namespace and domain-config configmap.
+  authmanager-2-0-0:
+    namespace: kernel-2-0-0
+    enabled: false
+    version: 12.0.1
+    chart: mosip/authmanager
+    set:
+      enable_insecure: "false"
+    wait: true
+    timeout: 600
+    priority: -8
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/kernel-preinstall.sh"
+      preUpgrade: "$WORKDIR/hooks/esignet-standalone-2.0.0/kernel-preinstall.sh"
+
+  auditmanager-2-0-0:
+    namespace: kernel-2-0-0
+    enabled: false
+    version: 12.0.1
+    chart: mosip/auditmanager
+    set:
+      enable_insecure: "false"
+    wait: true
+    timeout: 600
+    priority: -8
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/kernel-preinstall.sh"
+      preUpgrade: "$WORKDIR/hooks/esignet-standalone-2.0.0/kernel-preinstall.sh"
+
+  otpmanager-2-0-0:
+    namespace: kernel-2-0-0
+    enabled: false
+    version: 12.0.1
+    chart: mosip/otpmanager
+    wait: true
+    timeout: 600
+    priority: -8
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/kernel-preinstall.sh"
+      preUpgrade: "$WORKDIR/hooks/esignet-standalone-2.0.0/kernel-preinstall.sh"
+
+  notifier-2-0-0:
+    namespace: kernel-2-0-0
+    enabled: false
+    version: 12.0.1
+    chart: mosip/notifier
+    wait: true
+    timeout: 600
+    priority: -7
+    hooks:
+      postInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/notifier-postinstall.sh"
+      postUpgrade: "$WORKDIR/hooks/esignet-standalone-2.0.0/notifier-postinstall.sh"
+
+  # ---------------------------------------------------------------------------
+  # Mock SMTP (Optional — dev/test email and SMS)
+  # ---------------------------------------------------------------------------
+  mock-smtp-2-0-0:
+    namespace: mock-smtp-2-0-0
+    enabled: false
+    version: 1.0.0
+    chart: mosip/mock-smtp
+    set:
+      istio.hosts[0]: "smtp-2-0-0.${domain_name}"
+    wait: true
+    timeout: 300
+    priority: -5
+
+  # ---------------------------------------------------------------------------
+  # Signup Service (with esignet-mock-plugin)
+  # ---------------------------------------------------------------------------
+  # signup-service-preinstall.sh copies redis secrets, creates keycloak-host
+  # configmap, signup-captcha and signup-keystore secrets, and msg-gateway
+  # configmap/secret pointing to mock-smtp.
+  signup-2-0-0:
+    namespace: signup-2-0-0
+    enabled: false
+    version: 1.2.2
+    chart: mosip/signup
+    set:
+      image.repository: "mosipid/signup-service"
+      image.tag: "1.2.2"
+      enable_insecure: "false"
+      plugin_name_env: "esignet-mock-plugin.jar"
+      domainConfig.MOSIP_ESIGNET_HOST: "esignet-2-0-0.${domain_name}"
+      domainConfig.MOSIP_SIGNUP_HOST: "signup-2-0-0.${domain_name}"
+      domainConfig.MOSIP_IAM_EXTERNAL_HOST: "iam.${domain_name}"
+    wait: true
+    timeout: 600
+    priority: -4
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/signup-service-preinstall.sh"
+      preUpgrade: "$WORKDIR/hooks/esignet-standalone-2.0.0/signup-service-preinstall.sh"
+
+  # ---------------------------------------------------------------------------
+  # Signup UI
+  # ---------------------------------------------------------------------------
+  signup-ui-2-0-0:
+    namespace: signup-2-0-0
+    enabled: false
+    version: 1.2.2
+    chart: mosip/signup-ui
+    set:
+      image.repository: "mosipid/signup-ui"
+      image.tag: "1.2.2"
+      istio.hosts[0]: "signup-2-0-0.${domain_name}"
+      signup_ui.signup_service_host: "signup-2-0-0.signup-2-0-0"
+      signup_ui.configmaps.signup-ui.REACT_APP_API_BASE_URL: "http://signup-2-0-0.signup-2-0-0/v1/signup"
+      signup_ui.configmaps.signup-ui.REACT_APP_SBI_DOMAIN_URI: "http://signup-2-0-0.signup-2-0-0"
+    wait: true
+    timeout: 600
+    priority: -3

--- a/Helmsman/dsf/esignet-standalone-2.0.0/testrigs-dsf.yaml
+++ b/Helmsman/dsf/esignet-standalone-2.0.0/testrigs-dsf.yaml
@@ -1,0 +1,276 @@
+helmDefaults:
+  tillerNamespace: kube-system
+  tillerless: true
+  install: true
+
+helmRepos:
+  bitnami: https://charts.bitnami.com/bitnami
+  mosip: https://mosip.github.io/mosip-helm
+
+# Apitestrigs deploy into service namespaces (no dedicated testrig namespaces):
+#   esignet-apitestrig            → esignet ns
+#   esignet-mosipid1-apitestrig   → esignet-mosipid1 ns
+#   esignet-mosipid2-apitestrig   → esignet-mosipid2 ns
+#   esignet-sunbird-apitestrig    → esignet-sunbird ns
+#   esignet-signup-apitestrig     → signup ns        (disabled — enable if signup deployed)
+#   signup-uitestrig              → signup-uitestrig  (disabled — enable if signup deployed)
+namespaces:
+  esignet-mosipid1-2-0-0:
+    protected: false
+  esignet-mock-2-0-0:
+    protected: false
+  esignet-mosipid2-2-0-0:
+    protected: false
+  esignet-sunbird-2-0-0:
+    protected: false
+  signup-2-0-0:
+    protected: false
+  signup-uitestrig-2-0-0:
+    protected: false
+
+apps:
+  # ---------------------------------------------------------------------------
+  # eSignet API Testrig — main esignet namespace
+  # ---------------------------------------------------------------------------
+  esignet-apitestrig-2-0-0:
+    namespace: esignet-mock-2-0-0
+    enabled: true
+    version: 0.0.1-develop
+    chart: mosip/apitestrig
+    valuesFile: "$WORKDIR/utils/esignet-apitestrig-values.yaml"
+    set:
+      extraEnvVarsCM[0]: "esignet-global"
+      extraEnvVarsCM[1]: "s3"
+      extraEnvVarsCM[2]: "keycloak-host"
+      extraEnvVarsCM[3]: "db"
+      extraEnvVarsCM[4]: "apitestrig"    
+      extraEnvVarsSecret[0]: "apitestrig-esignet-apitestrig"
+      extraEnvVarsSecret[1]: "s3-esignet-apitestrig"
+      extraEnvVarsSecret[2]: "keycloak-client-secrets"
+      extraEnvVarsSecret[3]: "postgres-postgresql"
+      crontime: "0 2 * * *"
+      apitestrig.configmaps.s3.s3-host: 'http://minio.minio:9000'
+      apitestrig.configmaps.s3.s3-user-key: 'admin'
+      apitestrig.configmaps.s3.s3-region: ''
+      apitestrig.configmaps.db.db-server: "api-internal.${domain_name}"
+      apitestrig.configmaps.db.db-su-user: "postgres"
+      apitestrig.configmaps.db.db-port: "${esignet_db_port}"
+      apitestrig.configmaps.apitestrig.ENV_USER: "api-internal.${env_name}"
+      apitestrig.configmaps.apitestrig.ENV_ENDPOINT: "https://api-internal.${domain_name}"
+      apitestrig.configmaps.apitestrig.ENV_TESTLEVEL: "smokeAndRegression"
+      apitestrig.configmaps.apitestrig.reportExpirationInDays: "3"
+      apitestrig.configmaps.apitestrig.slack-webhook-url: "${SLACK_WEBHOOK_URL}"
+      apitestrig.configmaps.apitestrig.eSignetDeployed: "yes"
+      apitestrig.configmaps.apitestrig.NS: "esignet-mock-2-0-0"
+      apitestrig.configmaps.apitestrig.servicesNotDeployed: ''
+      apitestrig.configmaps.apitestrig.uinGenerationProcessingDelayTimeInMilliSeconds: "90000"
+      apitestrig.configmaps.apitestrig.vidGenerationProcessingDelayTimeInMilliSeconds: "90000"
+      apitestrig.configmaps.apitestrig.uinGenMaxLoopCount: "20"
+      apitestrig.configmaps.apitestrig.eSignetbaseurl: "https://esignet-2-0-0.${domain_name}"
+      apitestrig.configmaps.apitestrig.esignetActuatorPropertySection: "classpath:/application-default.properties"
+      secrets.s3.s3-user-secret: "${MINIO_ROOT_PASSWORD}"
+      apitestrig.variables.push_reports_to_s3: "yes"
+    priority: -5
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/apitestrig-esignet-setup.sh"
+
+  # ---------------------------------------------------------------------------
+  # eSignet API Testrig — esignet-mosipid1 namespace (mosip-identity-plugin)
+  # ---------------------------------------------------------------------------
+  esignet-mosipid1-apitestrig-2-0-0:
+    namespace: esignet-mosipid1-2-0-0
+    enabled: true
+    version: 0.0.1-develop
+    chart: mosip/apitestrig
+    valuesFile: "$WORKDIR/utils/esignet-apitestrig-values.yaml"
+    set:
+      extraEnvVarsCM[0]: "esignet-global"
+      extraEnvVarsCM[1]: "s3"
+      extraEnvVarsCM[2]: "keycloak-host"
+      extraEnvVarsCM[3]: "db"
+      extraEnvVarsCM[4]: "apitestrig"
+      extraEnvVarsSecret[0]: "apitestrig-esignet-mosipid1-apitestrig"
+      extraEnvVarsSecret[1]: "s3-esignet-mosipid1-apitestrig"
+      extraEnvVarsSecret[2]: "keycloak-client-secrets"
+      extraEnvVarsSecret[3]: "postgres-postgresql"
+      crontime: "0 2 * * *"
+      apitestrig.configmaps.s3.s3-host: 'http://minio.minio:9000'
+      apitestrig.configmaps.s3.s3-user-key: 'admin'
+      apitestrig.configmaps.s3.s3-region: ''
+      apitestrig.configmaps.db.db-server: "api-internal.${mosipid1_domain_name}"
+      apitestrig.configmaps.db.db-su-user: "postgres"
+      apitestrig.configmaps.db.db-port: "${esignet_db_port}"
+      apitestrig.configmaps.apitestrig.ENV_USER: "api-internal.${env_name}"
+      apitestrig.configmaps.apitestrig.ENV_ENDPOINT: "https://api-internal.${domain_name}"
+      apitestrig.configmaps.apitestrig.ENV_TESTLEVEL: "smokeAndRegression"
+      apitestrig.configmaps.apitestrig.reportExpirationInDays: "3"
+      apitestrig.configmaps.apitestrig.slack-webhook-url: "${SLACK_WEBHOOK_URL}"
+      apitestrig.configmaps.apitestrig.eSignetDeployed: "yes"
+      apitestrig.configmaps.apitestrig.NS: "esignet-mosipid1-2-0-0"
+      apitestrig.configmaps.apitestrig.servicesNotDeployed: 'sunbirdrc'
+      apitestrig.configmaps.apitestrig.uinGenerationProcessingDelayTimeInMilliSeconds: "90000"
+      apitestrig.configmaps.apitestrig.vidGenerationProcessingDelayTimeInMilliSeconds: "90000"
+      apitestrig.configmaps.apitestrig.uinGenMaxLoopCount: "20"
+      apitestrig.configmaps.apitestrig.eSignetbaseurl: "https://esignet-mosipid1-2-0-0.${domain_name}"
+      apitestrig.configmaps.apitestrig.esignetActuatorPropertySection: "classpath:/application-default.properties"
+      apitestrig.configmaps.apitestrig.mosip_components_base_urls: "auditmanager=api-internal.${mosipid1_domain_name};idrepository=api-internal.${mosipid1_domain_name};authmanager=api-internal.${mosipid1_domain_name};resident=api-internal.${mosipid1_domain_name};partnermanager=pms-mosipid1-2-0-0.${mosipid1_domain_name};idauthentication=api-internal.${mosipid1_domain_name};masterdata=api-internal.${mosipid1_domain_name};idgenerator=api-internal.${mosipid1_domain_name};policymanager=pms-mosipid1-2-0-0.${mosipid1_domain_name};preregistration=api-internal.${mosipid1_domain_name};keymanager=api-internal.${mosipid1_domain_name};"
+      secrets.s3.s3-user-secret: "${MINIO_ROOT_PASSWORD}"
+      apitestrig.variables.push_reports_to_s3: "yes"
+    priority: -4
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/apitestrig-esignet-mosipid1-setup.sh"
+
+  # ---------------------------------------------------------------------------
+  # eSignet API Testrig — esignet-mosipid2 namespace (mosip-identity-plugin)
+  # ---------------------------------------------------------------------------
+  esignet-mosipid2-apitestrig-2-0-0:
+    namespace: esignet-mosipid2-2-0-0
+    enabled: true
+    version: 0.0.1-develop
+    chart: mosip/apitestrig
+    valuesFile: "$WORKDIR/utils/esignet-apitestrig-values.yaml"
+    set:
+      extraEnvVarsCM[0]: "esignet-global"
+      extraEnvVarsCM[1]: "s3"
+      extraEnvVarsCM[2]: "keycloak-host"
+      extraEnvVarsCM[3]: "db"
+      extraEnvVarsCM[4]: "apitestrig"
+      extraEnvVarsSecret[0]: "apitestrig-esignet-mosipid2-apitestrig"
+      extraEnvVarsSecret[1]: "s3-esignet-mosipid2-apitestrig"
+      extraEnvVarsSecret[2]: "keycloak-client-secrets"
+      extraEnvVarsSecret[3]: "postgres-postgresql"
+      crontime: "0 2 * * *"
+      apitestrig.configmaps.s3.s3-host: 'http://minio.minio:9000'
+      apitestrig.configmaps.s3.s3-user-key: 'admin'
+      apitestrig.configmaps.s3.s3-region: ''
+      apitestrig.configmaps.db.db-server: "api-internal.${mosipid2_domain_name}"
+      apitestrig.configmaps.db.db-su-user: "postgres"
+      apitestrig.configmaps.db.db-port: "${esignet_db_port}"
+      apitestrig.configmaps.apitestrig.ENV_USER: "api-internal.${env_name}"
+      apitestrig.configmaps.apitestrig.ENV_ENDPOINT: "https://api-internal.${domain_name}"
+      apitestrig.configmaps.apitestrig.ENV_TESTLEVEL: "smokeAndRegression"
+      apitestrig.configmaps.apitestrig.reportExpirationInDays: "3"
+      apitestrig.configmaps.apitestrig.slack-webhook-url: "${SLACK_WEBHOOK_URL}"
+      apitestrig.configmaps.apitestrig.eSignetDeployed: "yes"
+      apitestrig.configmaps.apitestrig.NS: "esignet-mosipid2-2-0-0"
+      apitestrig.configmaps.apitestrig.servicesNotDeployed: 'sunbirdrc'
+      apitestrig.configmaps.apitestrig.uinGenerationProcessingDelayTimeInMilliSeconds: "90000"
+      apitestrig.configmaps.apitestrig.vidGenerationProcessingDelayTimeInMilliSeconds: "90000"
+      apitestrig.configmaps.apitestrig.uinGenMaxLoopCount: "20"
+      apitestrig.configmaps.apitestrig.eSignetbaseurl: "https://esignet-mosipid2-2-0-0.${domain_name}"
+      apitestrig.configmaps.apitestrig.esignetActuatorPropertySection: "classpath:/application-default.properties"
+      apitestrig.configmaps.apitestrig.mosip_components_base_urls: "auditmanager=api-internal.${mosipid2_domain_name};idrepository=api-internal.${mosipid2_domain_name};authmanager=api-internal.${mosipid2_domain_name};resident=api-internal.${mosipid2_domain_name};partnermanager=pms-mosipid2-2-0-0.${mosipid2_domain_name};idauthentication=api-internal.${mosipid2_domain_name};masterdata=api-internal.${mosipid2_domain_name};idgenerator=api-internal.${mosipid2_domain_name};policymanager=pms-mosipid2-2-0-0.${mosipid2_domain_name};preregistration=api-internal.${mosipid2_domain_name};keymanager=api-internal.${mosipid2_domain_name};"
+      secrets.s3.s3-user-secret: "${MINIO_ROOT_PASSWORD}"
+      apitestrig.variables.push_reports_to_s3: "yes"
+    priority: -3
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/apitestrig-esignet-mosipid2-setup.sh"
+
+  # ---------------------------------------------------------------------------
+  # eSignet API Testrig — esignet-sunbird namespace (sunbird-rc-plugin)
+  # postInstall triggers all four testrig namespaces after last one deploys.
+  # ---------------------------------------------------------------------------
+  esignet-sunbird-apitestrig-2-0-0:
+    namespace: esignet-sunbird-2-0-0
+    enabled: true
+    version: 0.0.1-develop
+    chart: mosip/apitestrig
+    valuesFile: "$WORKDIR/utils/esignet-apitestrig-values.yaml"
+    set:
+      extraEnvVarsCM[0]: "esignet-global"
+      extraEnvVarsCM[1]: "s3"
+      extraEnvVarsCM[2]: "keycloak-host"
+      extraEnvVarsCM[3]: "db"
+      extraEnvVarsCM[4]: "apitestrig"
+      extraEnvVarsSecret[0]: "apitestrig-esignet-sunbird-apitestrig"
+      extraEnvVarsSecret[1]: "s3-esignet-sunbird-apitestrig"
+      extraEnvVarsSecret[2]: "keycloak-client-secrets"
+      extraEnvVarsSecret[3]: "postgres-postgresql"
+      crontime: "0 2 * * *"
+      apitestrig.configmaps.s3.s3-host: 'http://minio.minio:9000'
+      apitestrig.configmaps.s3.s3-user-key: 'admin'
+      apitestrig.configmaps.s3.s3-region: ''
+      apitestrig.configmaps.db.db-server: "api-internal.${domain_name}"
+      apitestrig.configmaps.db.db-su-user: "postgres"
+      apitestrig.configmaps.db.db-port: "${esignet_db_port}"
+      apitestrig.configmaps.apitestrig.ENV_USER: "api-internal.${env_name}"
+      apitestrig.configmaps.apitestrig.ENV_ENDPOINT: "https://api-internal.${domain_name}"
+      apitestrig.configmaps.apitestrig.ENV_TESTLEVEL: "smokeAndRegression"
+      apitestrig.configmaps.apitestrig.reportExpirationInDays: "3"
+      apitestrig.configmaps.apitestrig.slack-webhook-url: "${SLACK_WEBHOOK_URL}"
+      apitestrig.configmaps.apitestrig.eSignetDeployed: "yes"
+      apitestrig.configmaps.apitestrig.NS: "esignet-sunbird-2-0-0"
+      apitestrig.configmaps.apitestrig.servicesNotDeployed: ''
+      apitestrig.configmaps.apitestrig.uinGenerationProcessingDelayTimeInMilliSeconds: "90000"
+      apitestrig.configmaps.apitestrig.vidGenerationProcessingDelayTimeInMilliSeconds: "90000"
+      apitestrig.configmaps.apitestrig.uinGenMaxLoopCount: "20"
+      apitestrig.configmaps.apitestrig.eSignetbaseurl: "https://esignet-sunbird-2-0-0.${domain_name}"
+      apitestrig.configmaps.apitestrig.esignetActuatorPropertySection: "classpath:/application-default.properties"
+      apitestrig.configmaps.apitestrig.sunBirdBaseURL: "https://registry.${mosipid1_domain_name}"
+      secrets.s3.s3-user-secret: "${MINIO_ROOT_PASSWORD}"
+      apitestrig.variables.push_reports_to_s3: "yes"
+    priority: -2
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/apitestrig-esignet-sunbird-setup.sh"
+      # postInstall: "$WORKDIR/hooks/esignet-standalone/trigger-test-jobs-esignet.sh"
+
+  # ---------------------------------------------------------------------------
+  # Signup API Test Rig — disabled by default
+  # Enable only if signup stack (signup-dsf) is deployed.
+  # ---------------------------------------------------------------------------
+  esignet-signup-apitestrig-2-0-0:
+    namespace: signup-2-0-0
+    enabled: false
+    version: 0.0.1-develop
+    chart: mosip/apitestrig
+    valuesFile: "$WORKDIR/utils/esignet-signup-apitestrig-values.yaml"
+    set:
+      crontime: "0 2 * * *"
+      apitestrig.configmaps.s3.s3-host: 'http://minio.minio:9000'
+      apitestrig.configmaps.s3.s3-user-key: 'admin'
+      apitestrig.configmaps.s3.s3-region: ''
+      apitestrig.configmaps.db.db-server: "api-internal.${domain_name}"
+      apitestrig.configmaps.db.db-su-user: "postgres"
+      apitestrig.configmaps.db.db-port: "${esignet_db_port}"
+      apitestrig.configmaps.apitestrig.ENV_USER: "api-internal.${env_name}"
+      apitestrig.configmaps.apitestrig.ENV_ENDPOINT: "https://api-internal.${domain_name}"
+      apitestrig.configmaps.apitestrig.ENV_TESTLEVEL: "smokeAndRegression"
+      apitestrig.configmaps.apitestrig.reportExpirationInDays: "3"
+      apitestrig.configmaps.apitestrig.slack-webhook-url: "${SLACK_WEBHOOK_URL}"
+      apitestrig.configmaps.apitestrig.eSignetDeployed: "yes"
+      apitestrig.configmaps.apitestrig.NS: "signup-2-0-0"
+      apitestrig.configmaps.apitestrig.servicesNotDeployed: ''
+      secrets.s3.s3-user-secret: "${MINIO_ROOT_PASSWORD}"
+      apitestrig.variables.push_reports_to_s3: "yes"
+    priority: -2
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/apitestrig-signup-setup.sh"
+
+  # ---------------------------------------------------------------------------
+  # Signup UI Test Rig — disabled by default
+  # Enable only if signup stack (signup-dsf) is deployed.
+  # ---------------------------------------------------------------------------
+  signup-uitestrig-2-0-0:
+    namespace: signup-uitestrig-2-0-0
+    enabled: false
+    version: 0.0.1-develop
+    chart: mosip/uitestrig
+    valuesFile: "$WORKDIR/utils/signup-uitestrig-values.yaml"
+    set:
+      crontime: "0 3 * * *"
+      uitestrig.configmaps.s3.s3-host: "http://minio.minio:9000"
+      uitestrig.configmaps.s3.s3-user-key: "admin"
+      uitestrig.configmaps.s3.s3-region: ""
+      uitestrig.configmaps.db.db-server: "api-internal.${domain_name}"
+      uitestrig.configmaps.db.db-su-user: "postgres"
+      uitestrig.configmaps.db.db-port: "${esignet_db_port}"
+      uitestrig.configmaps.uitestrig.ENV_USER: "api-internal.${env_name}"
+      uitestrig.configmaps.uitestrig.ENV_ENDPOINT: "https://api-internal.${domain_name}"
+      uitestrig.configmaps.uitestrig.reportExpirationInDays: "3"
+      uitestrig.configmaps.uitestrig.slack-webhook-url: "${SLACK_WEBHOOK_URL}"
+      uitestrig.configmaps.uitestrig.eSignetDeployed: "yes"
+      uitestrig.configmaps.uitestrig.NS: "signup-uitestrig-2-0-0"
+      uitestrig.variables.push_reports_to_s3: "yes"
+    priority: -1
+    hooks:
+      preInstall: "$WORKDIR/hooks/esignet-standalone-2.0.0/uitestrig-signup-setup.sh"

--- a/Helmsman/dsf/esignet-standalone/external-dsf.yaml
+++ b/Helmsman/dsf/esignet-standalone/external-dsf.yaml
@@ -174,6 +174,70 @@ apps:
       databases.mosip_mockidentitysystem.repoUrl: "https://github.com/mosip/esignet-mock-services.git"
       databases.mosip_mockidentitysystem.port: ${esignet_db_port}
       databases.mosip_mockidentitysystem.dml: 1
+      # ---------------------------------------------------------------------------
+      # esignet-standalone-2.0.0 profile — isolated databases (own data, shared postgres)
+      # ---------------------------------------------------------------------------
+      databases.mosip_esignet_2_0_0.enabled: "true"
+      databases.mosip_esignet_2_0_0.scriptsDir: "mosip_esignet"
+      databases.mosip_esignet_2_0_0.dbName: "mosip_esignet_2_0_0"
+      databases.mosip_esignet_2_0_0.dbUser: "esignetuser_2_0_0"
+      databases.mosip_esignet_2_0_0.branch: "develop"
+      databases.mosip_esignet_2_0_0.host: "postgres.${domain_name}"
+      databases.mosip_esignet_2_0_0.port: ${esignet_db_port}
+      databases.mosip_esignet_2_0_0.dml: 1
+      databases.mosip_esignet_2_0_0.repoUrl: "https://github.com/mosip/esignet.git"
+      databases.mosip_esignet_2_0_0.defaultDb: "postgres"
+      databases.mosip_esignet_2_0_0.su.user: "postgres"
+      databases.mosip_esignet_2_0_0.su.secret.name: "postgres-postgresql"
+      databases.mosip_esignet_2_0_0.su.secret.key: "postgres-password"
+      databases.mosip_esignet_mosipid1_2_0_0.enabled: "true"
+      databases.mosip_esignet_mosipid1_2_0_0.scriptsDir: "mosip_esignet"
+      databases.mosip_esignet_mosipid1_2_0_0.dbName: "mosip_esignet_mosipid1_2_0_0"
+      databases.mosip_esignet_mosipid1_2_0_0.dbUser: "esignetuser_mosipid1_2_0_0"
+      databases.mosip_esignet_mosipid1_2_0_0.branch: "develop"
+      databases.mosip_esignet_mosipid1_2_0_0.host: "postgres.${domain_name}"
+      databases.mosip_esignet_mosipid1_2_0_0.port: ${esignet_db_port}
+      databases.mosip_esignet_mosipid1_2_0_0.dml: 1
+      databases.mosip_esignet_mosipid1_2_0_0.repoUrl: "https://github.com/mosip/esignet.git"
+      databases.mosip_esignet_mosipid1_2_0_0.defaultDb: "postgres"
+      databases.mosip_esignet_mosipid1_2_0_0.su.user: "postgres"
+      databases.mosip_esignet_mosipid1_2_0_0.su.secret.name: "postgres-postgresql"
+      databases.mosip_esignet_mosipid1_2_0_0.su.secret.key: "postgres-password"
+      databases.mosip_esignet_mosipid2_2_0_0.enabled: "true"
+      databases.mosip_esignet_mosipid2_2_0_0.scriptsDir: "mosip_esignet"
+      databases.mosip_esignet_mosipid2_2_0_0.dbName: "mosip_esignet_mosipid2_2_0_0"
+      databases.mosip_esignet_mosipid2_2_0_0.dbUser: "esignetuser_mosipid2_2_0_0"
+      databases.mosip_esignet_mosipid2_2_0_0.branch: "develop"
+      databases.mosip_esignet_mosipid2_2_0_0.host: "postgres.${domain_name}"
+      databases.mosip_esignet_mosipid2_2_0_0.port: ${esignet_db_port}
+      databases.mosip_esignet_mosipid2_2_0_0.dml: 1
+      databases.mosip_esignet_mosipid2_2_0_0.repoUrl: "https://github.com/mosip/esignet.git"
+      databases.mosip_esignet_mosipid2_2_0_0.defaultDb: "postgres"
+      databases.mosip_esignet_mosipid2_2_0_0.su.user: "postgres"
+      databases.mosip_esignet_mosipid2_2_0_0.su.secret.name: "postgres-postgresql"
+      databases.mosip_esignet_mosipid2_2_0_0.su.secret.key: "postgres-password"
+      databases.mosip_esignet_sunbird_2_0_0.enabled: "true"
+      databases.mosip_esignet_sunbird_2_0_0.scriptsDir: "mosip_esignet"
+      databases.mosip_esignet_sunbird_2_0_0.dbName: "mosip_esignet_sunbird_2_0_0"
+      databases.mosip_esignet_sunbird_2_0_0.dbUser: "esignetuser_sunbird_2_0_0"
+      databases.mosip_esignet_sunbird_2_0_0.branch: "develop"
+      databases.mosip_esignet_sunbird_2_0_0.host: "postgres.${domain_name}"
+      databases.mosip_esignet_sunbird_2_0_0.port: ${esignet_db_port}
+      databases.mosip_esignet_sunbird_2_0_0.dml: 1
+      databases.mosip_esignet_sunbird_2_0_0.repoUrl: "https://github.com/mosip/esignet.git"
+      databases.mosip_esignet_sunbird_2_0_0.defaultDb: "postgres"
+      databases.mosip_esignet_sunbird_2_0_0.su.user: "postgres"
+      databases.mosip_esignet_sunbird_2_0_0.su.secret.name: "postgres-postgresql"
+      databases.mosip_esignet_sunbird_2_0_0.su.secret.key: "postgres-password"
+      databases.mosip_mockidentitysystem_2_0_0.enabled: "true"
+      databases.mosip_mockidentitysystem_2_0_0.scriptsDir: "mosip_mockidentitysystem"
+      databases.mosip_mockidentitysystem_2_0_0.dbName: "mosip_mockidentitysystem_2_0_0"
+      databases.mosip_mockidentitysystem_2_0_0.dbUser: "mockidentityuser_2_0_0"
+      databases.mosip_mockidentitysystem_2_0_0.branch: "develop"
+      databases.mosip_mockidentitysystem_2_0_0.host: "postgres.${domain_name}"
+      databases.mosip_mockidentitysystem_2_0_0.repoUrl: "https://github.com/mosip/esignet-mock-services.git"
+      databases.mosip_mockidentitysystem_2_0_0.port: ${esignet_db_port}
+      databases.mosip_mockidentitysystem_2_0_0.dml: 1
     wait: true
     timeout: 300
     priority: -16
@@ -230,6 +294,27 @@ apps:
       databases.mosip_otp.host: "postgres.${domain_name}"
       databases.mosip_otp.port: ${esignet_db_port}
       databases.mosip_otp.dml: 0
+      # ---------------------------------------------------------------------------
+      # esignet-standalone-2.0.0 profile — isolated signup/kernel databases
+      # ---------------------------------------------------------------------------
+      databases.mosip_audit_2_0_0.enabled: "true"
+      databases.mosip_audit_2_0_0.branch: "v1.2.0.1"
+      databases.mosip_audit_2_0_0.repoUrl: "https://github.com/mosip/audit-manager.git"
+      databases.mosip_audit_2_0_0.host: "postgres.${domain_name}"
+      databases.mosip_audit_2_0_0.port: ${esignet_db_port}
+      databases.mosip_audit_2_0_0.dml: 0
+      databases.mosip_kernel_2_0_0.enabled: "true"
+      databases.mosip_kernel_2_0_0.branch: "v1.2.0.1"
+      databases.mosip_kernel_2_0_0.repoUrl: "https://github.com/mosip/commons.git"
+      databases.mosip_kernel_2_0_0.host: "postgres.${domain_name}"
+      databases.mosip_kernel_2_0_0.port: ${esignet_db_port}
+      databases.mosip_kernel_2_0_0.dml: 0
+      databases.mosip_otp_2_0_0.enabled: "true"
+      databases.mosip_otp_2_0_0.branch: "v1.2.0.1"
+      databases.mosip_otp_2_0_0.repoUrl: "https://github.com/mosip/otp-manager.git"
+      databases.mosip_otp_2_0_0.host: "postgres.${domain_name}"
+      databases.mosip_otp_2_0_0.port: ${esignet_db_port}
+      databases.mosip_otp_2_0_0.dml: 0
     wait: true
     timeout: 300
     priority: -16

--- a/Helmsman/hooks/esignet-standalone-2.0.0/apitestrig-esignet-mosipid1-setup.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/apitestrig-esignet-mosipid1-setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - eSignet-MOSIPID1 API Testrig Pre-install Setup
+# =============================================================================
+# Prepares the esignet-mosipid1 namespace for the esignet-mosipid1-apitestrig release.
+# keycloak-host and keycloak-client-secrets are already present in esignet-mosipid1
+# (copied by esignet-postinstall-keycloak-init.sh). Only postgres-postgresql
+# needs to be copied; stale testrig CMs are deleted so the chart recreates them.
+# =============================================================================
+set -euo pipefail
+
+NS=esignet-mosipid1-2-0-0
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - eSignet-MOSIPID1 API Testrig Pre-install"
+echo "================================================"
+
+echo "Deleting stale testrig configmaps in $NS"
+kubectl -n "$NS" delete --ignore-not-found=true configmap s3
+kubectl -n "$NS" delete --ignore-not-found=true configmap db
+kubectl -n "$NS" delete --ignore-not-found=true configmap apitestrig
+
+echo "Copying postgres-postgresql secret to $NS"
+$COPY_UTIL secret postgres-postgresql postgres "$NS"
+
+echo "eSignet-MOSIPID1 API Testrig pre-install setup completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/apitestrig-esignet-mosipid2-setup.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/apitestrig-esignet-mosipid2-setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - eSignet-MOSIPID2 API Testrig Pre-install Setup
+# =============================================================================
+# Prepares the esignet-mosipid2 namespace for the esignet-mosipid2-apitestrig release.
+# keycloak-host and keycloak-client-secrets are already present in esignet-mosipid2
+# (copied by esignet-postinstall-keycloak-init.sh). Only postgres-postgresql
+# needs to be copied; stale testrig CMs are deleted so the chart recreates them.
+# =============================================================================
+set -euo pipefail
+
+NS=esignet-mosipid2-2-0-0
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - eSignet-MOSIPID2 API Testrig Pre-install"
+echo "================================================"
+
+echo "Deleting stale testrig configmaps in $NS"
+kubectl -n "$NS" delete --ignore-not-found=true configmap s3
+kubectl -n "$NS" delete --ignore-not-found=true configmap db
+kubectl -n "$NS" delete --ignore-not-found=true configmap apitestrig
+
+echo "Copying postgres-postgresql secret to $NS"
+$COPY_UTIL secret postgres-postgresql postgres "$NS"
+
+echo "eSignet-MOSIPID2 API Testrig pre-install setup completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/apitestrig-esignet-setup.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/apitestrig-esignet-setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - eSignet API Testrig Pre-install Setup
+# =============================================================================
+# Prepares the esignet-mock namespace for the esignet-apitestrig release.
+# keycloak-host and keycloak-client-secrets are already present in esignet-mock ns
+# (copied by esignet-postinstall-keycloak-init.sh). Only postgres-postgresql
+# needs to be copied; stale testrig CMs are deleted so the chart recreates them.
+# =============================================================================
+set -euo pipefail
+
+NS=esignet-mock-2-0-0
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - eSignet API Testrig Pre-install"
+echo "================================================"
+
+echo "Deleting stale testrig configmaps in $NS"
+kubectl -n "$NS" delete --ignore-not-found=true configmap s3
+kubectl -n "$NS" delete --ignore-not-found=true configmap db
+kubectl -n "$NS" delete --ignore-not-found=true configmap apitestrig
+
+echo "Copying postgres-postgresql secret to $NS"
+$COPY_UTIL secret postgres-postgresql postgres "$NS"
+
+echo "eSignet API Testrig pre-install setup completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/apitestrig-esignet-sunbird-setup.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/apitestrig-esignet-sunbird-setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - eSignet-Sunbird API Testrig Pre-install Setup
+# =============================================================================
+# Prepares the esignet-sunbird namespace for the esignet-sunbird-apitestrig release.
+# keycloak-host and keycloak-client-secrets are already present in esignet-sunbird
+# (copied by esignet-postinstall-keycloak-init.sh). Only postgres-postgresql
+# needs to be copied; stale testrig CMs are deleted so the chart recreates them.
+# =============================================================================
+set -euo pipefail
+
+NS=esignet-sunbird-2-0-0
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - eSignet-Sunbird API Testrig Pre-install"
+echo "================================================"
+
+echo "Deleting stale testrig configmaps in $NS"
+kubectl -n "$NS" delete --ignore-not-found=true configmap s3
+kubectl -n "$NS" delete --ignore-not-found=true configmap db
+kubectl -n "$NS" delete --ignore-not-found=true configmap apitestrig
+
+echo "Copying postgres-postgresql secret to $NS"
+$COPY_UTIL secret postgres-postgresql postgres "$NS"
+
+echo "eSignet-Sunbird API Testrig pre-install setup completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/apitestrig-signup-setup.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/apitestrig-signup-setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Signup API Testrig Pre-install Setup
+# =============================================================================
+# Prepares the signup namespace for the esignet-signup-apitestrig release.
+# keycloak-host and keycloak-client-secrets are already present in signup ns
+# (copied by signup-keycloak-init-postinstall.sh). Only postgres-postgresql
+# needs to be copied; stale testrig CMs are deleted so the chart recreates them.
+# =============================================================================
+set -euo pipefail
+
+NS=signup-2-0-0
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Signup API Testrig Pre-install"
+echo "================================================"
+
+echo "Deleting stale testrig configmaps in $NS"
+kubectl -n "$NS" delete --ignore-not-found=true configmap s3
+kubectl -n "$NS" delete --ignore-not-found=true configmap db
+kubectl -n "$NS" delete --ignore-not-found=true configmap apitestrig
+
+echo "Copying postgres-postgresql secret to $NS"
+$COPY_UTIL secret postgres-postgresql postgres "$NS"
+
+echo "Signup API Testrig pre-install setup completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/captcha-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/captcha-postinstall.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Captcha Post-install
+# =============================================================================
+# Based on: deploy/captcha/install.sh
+# Configures captcha secrets for eSignet and patches captcha deployment
+# with the secret key environment variable.
+#
+# Environment Variables:
+#   CAPTCHA_SITE_KEY     - reCAPTCHA site key (REQUIRED)
+#   CAPTCHA_SECRET_KEY   - reCAPTCHA secret key (REQUIRED)
+#   ESIGNET_NS           - eSignet namespace (default: esignet)
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+CAPTCHA_NS="captcha"
+CAPTCHA_SITE_KEY="${ESIGNET_CAPTCHA_SITE_KEY:?ERROR: ESIGNET_CAPTCHA_SITE_KEY environment variable must be set}"
+CAPTCHA_SECRET_KEY="${ESIGNET_CAPTCHA_SECRET_KEY:?ERROR: ESIGNET_CAPTCHA_SECRET_KEY environment variable must be set}"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Captcha Post-install"
+echo "================================================"
+
+# --- Step 1: Create captcha secrets for eSignet ---
+echo "Creating esignet-captcha secret in $ESIGNET_NS namespace"
+kubectl -n "$ESIGNET_NS" create secret generic esignet-captcha \
+  --from-literal=esignet-captcha-site-key="$CAPTCHA_SITE_KEY" \
+  --from-literal=esignet-captcha-secret-key="$CAPTCHA_SECRET_KEY" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# --- Step 2: Copy captcha secret to captcha namespace ---
+echo "Copying esignet-captcha secret to $CAPTCHA_NS namespace"
+$COPY_UTIL secret esignet-captcha "$ESIGNET_NS" "$CAPTCHA_NS"
+
+# --- Step 3: Patch captcha deployment with secret env var ---
+echo "Patching captcha deployment with secret key environment variable"
+ENV_VAR_EXISTS=$(kubectl -n "$CAPTCHA_NS" get deployment captcha -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNET')].name}" 2>/dev/null || echo "")
+
+if [[ -z "$ENV_VAR_EXISTS" ]]; then
+  echo "Adding MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNET env var..."
+  ENV_ARRAY_EXISTS=$(kubectl -n "$CAPTCHA_NS" get deployment captcha \
+    -o jsonpath="{.spec.template.spec.containers[0].env}" 2>/dev/null || echo "")
+  if [[ -z "$ENV_ARRAY_EXISTS" ]]; then
+    echo "env array not found, initializing..."
+    kubectl patch deployment -n "$CAPTCHA_NS" captcha --type='json' \
+      -p='[{"op": "add", "path": "/spec/template/spec/containers/0/env", "value": []}]'
+  fi
+  kubectl patch deployment -n "$CAPTCHA_NS" captcha --type='json' \
+    -p='[{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNET", "valueFrom": {"secretKeyRef": {"name": "esignet-captcha", "key": "esignet-captcha-secret-key"}}}}]'
+else
+  echo "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNET env var already exists."
+fi
+
+echo "Captcha post-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/captcha-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/captcha-postinstall.sh
@@ -24,22 +24,22 @@ echo "eSignet 1.7.1 - Captcha Post-install"
 echo "================================================"
 
 # --- Step 1: Create captcha secrets for eSignet ---
-echo "Creating esignet-captcha secret in $ESIGNET_NS namespace"
-kubectl -n "$ESIGNET_NS" create secret generic esignet-captcha \
-  --from-literal=esignet-captcha-site-key="$CAPTCHA_SITE_KEY" \
-  --from-literal=esignet-captcha-secret-key="$CAPTCHA_SECRET_KEY" \
+echo "Creating esignet-captcha-2-0-0 secret in $ESIGNET_NS namespace"
+kubectl -n "$ESIGNET_NS" create secret generic esignet-captcha-2-0-0 \
+  --from-literal=esignet-captcha-2-0-0-site-key="$CAPTCHA_SITE_KEY" \
+  --from-literal=esignet-captcha-2-0-0-secret-key="$CAPTCHA_SECRET_KEY" \
   --dry-run=client -o yaml | kubectl apply -f -
 
 # --- Step 2: Copy captcha secret to captcha namespace ---
-echo "Copying esignet-captcha secret to $CAPTCHA_NS namespace"
-$COPY_UTIL secret esignet-captcha "$ESIGNET_NS" "$CAPTCHA_NS"
+echo "Copying esignet-captcha-2-0-0 secret to $CAPTCHA_NS namespace"
+$COPY_UTIL secret esignet-captcha-2-0-0 "$ESIGNET_NS" "$CAPTCHA_NS"
 
 # --- Step 3: Patch captcha deployment with secret env var ---
 echo "Patching captcha deployment with secret key environment variable"
-ENV_VAR_EXISTS=$(kubectl -n "$CAPTCHA_NS" get deployment captcha -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNET')].name}" 2>/dev/null || echo "")
+ENV_VAR_EXISTS=$(kubectl -n "$CAPTCHA_NS" get deployment captcha -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNET_2_0_0')].name}" 2>/dev/null || echo "")
 
 if [[ -z "$ENV_VAR_EXISTS" ]]; then
-  echo "Adding MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNET env var..."
+  echo "Adding MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNET_2_0_0 env var..."
   ENV_ARRAY_EXISTS=$(kubectl -n "$CAPTCHA_NS" get deployment captcha \
     -o jsonpath="{.spec.template.spec.containers[0].env}" 2>/dev/null || echo "")
   if [[ -z "$ENV_ARRAY_EXISTS" ]]; then
@@ -48,9 +48,9 @@ if [[ -z "$ENV_VAR_EXISTS" ]]; then
       -p='[{"op": "add", "path": "/spec/template/spec/containers/0/env", "value": []}]'
   fi
   kubectl patch deployment -n "$CAPTCHA_NS" captcha --type='json' \
-    -p='[{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNET", "valueFrom": {"secretKeyRef": {"name": "esignet-captcha", "key": "esignet-captcha-secret-key"}}}}]'
+    -p='[{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNET_2_0_0", "valueFrom": {"secretKeyRef": {"name": "esignet-captcha-2-0-0", "key": "esignet-captcha-2-0-0-secret-key"}}}}]'
 else
-  echo "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNET env var already exists."
+  echo "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNET_2_0_0 env var already exists."
 fi
 
 echo "Captcha post-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/config-server-esignet-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/config-server-esignet-postinstall.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Config-Server eSignet Post-install
+# =============================================================================
+# Copies esignet-config-server-share CM from esignet-mock ns to mosipid1/mosipid2/sunbird,
+# then patches active_profile_env and spring_config_label_env per namespace
+# so each instance points to the correct config server profile and Git label.
+#
+# Environment variables (set in GitHub Actions workflow):
+#   ESIGNET_MOSIPID1_SPRING_CONFIG_LABEL  - Git label for esignet-mosipid1 (default: develop)
+#   ESIGNET_MOSIPID2_SPRING_CONFIG_LABEL  - Git label for esignet-mosipid2 (default: develop)
+# =============================================================================
+set -euo pipefail
+
+SOURCE_NS="esignet-mock-2-0-0"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+CM_NAME="esignet-config-server-share"
+
+MOSIPID1_SPRING_LABEL="${ESIGNET_MOSIPID1_SPRING_CONFIG_LABEL:-develop}"
+MOSIPID2_SPRING_LABEL="${ESIGNET_MOSIPID2_SPRING_CONFIG_LABEL:-develop}"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Config-Server eSignet Post-install"
+echo "================================================"
+
+for TARGET_NS in esignet-mosipid1-2-0-0 esignet-mosipid2-2-0-0 esignet-sunbird-2-0-0; do
+  echo "Copying $CM_NAME from $SOURCE_NS to $TARGET_NS"
+  $COPY_UTIL configmap "$CM_NAME" "$SOURCE_NS" "$TARGET_NS"
+done
+
+echo "Patching $CM_NAME in esignet-mosipid1-2-0-0 (active_profile_env=mosipid1, spring_config_label_env=$MOSIPID1_SPRING_LABEL)"
+kubectl -n esignet-mosipid1-2-0-0 patch configmap "$CM_NAME" --type merge \
+  -p "{\"data\":{\"active_profile_env\":\"mosipid1\",\"spring_config_label_env\":\"$MOSIPID1_SPRING_LABEL\"}}"
+
+echo "Patching $CM_NAME in esignet-mosipid2-2-0-0 (active_profile_env=mosipid2, spring_config_label_env=$MOSIPID2_SPRING_LABEL)"
+kubectl -n esignet-mosipid2-2-0-0 patch configmap "$CM_NAME" --type merge \
+  -p "{\"data\":{\"active_profile_env\":\"mosipid2\",\"spring_config_label_env\":\"$MOSIPID2_SPRING_LABEL\"}}"
+
+echo "Config-server share configmap propagation and patching completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/config-server-esignet-setup.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/config-server-esignet-setup.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Config-Server eSignet Pre-install
+# =============================================================================
+# Based on: esignet/deploy/config-server/install.sh
+#
+# Prepares esignet namespace for config-server deployment:
+#   1. Ensures namespace exists with Istio injection enabled
+#   2. Copies db-common-secrets from postgres ns
+#   3. Creates esignet-global ConfigMap from workflow env vars
+#      (domain_name set by helmsman_esignet.yml; available as shell env var
+#      in all hooks run within the same workflow step)
+#   4. Pre-creates empty esignet-misp-onboarder-key secret as placeholder
+#      (MISP onboarder at priority -6 writes the real key; config-server is
+#      restarted by esignet-misp-onboarder-postinstall.sh afterwards)
+#
+# NOTE: esignet-softhsm secret is NOT copied here — the softhsm helm chart
+# installs directly into the esignet namespace, so no cross-namespace copy needed.
+#
+# NOTE: keycloak resources (keycloak-host, keycloak-env-vars, keycloak,
+# keycloak-client-secrets) are NOT copied here. They are populated in all
+# esignet namespaces by esignet-postinstall-keycloak-init.sh which runs as
+# part of external-dsf (esignet-keycloak-init at priority -11 in keycloak ns).
+# By the time esignet-dsf runs, these resources are already present.
+#
+# Environment Variables:
+#   ESIGNET_NS   - eSignet namespace (default: esignet)
+#   domain_name  - base domain (set by workflow, e.g. sandbox.example.net)
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+POSTGRES_NS="postgres"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Config-Server eSignet Pre-install"
+echo "================================================"
+
+# --- Step 1: Ensure namespace with Istio ---
+kubectl create namespace "$ESIGNET_NS" --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace "$ESIGNET_NS" istio-injection=enabled --overwrite
+
+# --- Step 2: Copy db-common-secrets ---
+# NOTE: esignet-softhsm secret is NOT copied here — the softhsm helm chart
+# creates it directly in the esignet namespace as a helm-managed resource.
+echo "Copying db-common-secrets from $POSTGRES_NS"
+$COPY_UTIL secret db-common-secrets "$POSTGRES_NS" "$ESIGNET_NS"
+
+# --- Step 3: Create esignet-global from workflow env vars ---
+# domain_name is exported by the helmsman_esignet.yml workflow step
+echo "Creating esignet-global configmap (domain_name=${domain_name:-UNSET})"
+kubectl -n "$ESIGNET_NS" create configmap esignet-global \
+  --from-literal=installation-domain="${domain_name}" \
+  --from-literal=mosip-api-host="api.${domain_name}" \
+  --from-literal=mosip-api-internal-host="api-internal.${domain_name}" \
+  --from-literal=mosip-esignet-host="esignet-2-0-0.${domain_name}" \
+  --from-literal=mosip-iam-external-host="iam.${domain_name}" \
+  --from-literal=mosip-kafka-host="kafka.${domain_name}" \
+  --from-literal=mosip-postgres-host="postgres.${domain_name}" \
+  --from-literal=mosip-signup-host="signup-2-0-0.${domain_name}" \
+  --from-literal=mosip-smtp-host="smtp-2-0-0.${domain_name}" \
+  --from-literal=mosip-version="develop" \
+  --dry-run=client -o yaml | kubectl apply -f -
+echo "esignet-global created/updated."
+
+# --- Step 4: Pre-create empty MISP key secret as placeholder ---
+# Allows config-server pod to start. Real value written by MISP onboarder (-6).
+# esignet-misp-onboarder-postinstall.sh restarts config-server after writing.
+if ! kubectl -n "$ESIGNET_NS" get secret esignet-misp-onboarder-key &>/dev/null; then
+  kubectl -n "$ESIGNET_NS" create secret generic esignet-misp-onboarder-key \
+    --from-literal=mosip-esignet-misp-key=""
+  echo "esignet-misp-onboarder-key placeholder created."
+else
+  echo "esignet-misp-onboarder-key already exists, skipping placeholder."
+fi
+
+echo "Config-server eSignet pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/esignet-db-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/esignet-db-postinstall.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Database Init Post-install (postgres-init-esignet-mock)
+# =============================================================================
+# postgres-init-esignet-mock runs in the postgres namespace and creates
+# db-common-secrets there. This hook copies it to all esignet-mock namespaces
+# so each eSignet instance can use it for DB connections.
+# =============================================================================
+set -euo pipefail
+
+POSTGRES_NS="postgres"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Database Init Post-install"
+echo "================================================"
+
+for NS in esignet-mock-2-0-0 esignet-mosipid1-2-0-0 esignet-mosipid2-2-0-0 esignet-sunbird-2-0-0; do
+  echo "Copying db-common-secrets from $POSTGRES_NS to $NS"
+  $COPY_UTIL secret db-common-secrets "$POSTGRES_NS" "$NS"
+done
+
+echo "Database init post-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/esignet-init-db.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/esignet-init-db.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Database Init Pre-install (postgres-init-esignet-mock)
+# =============================================================================
+# Based on: deploy/postgres/postgres-init.sh
+# postgres-init-esignet-mock runs in the postgres namespace so it can access
+# postgres-postgresql secret natively. This hook pre-creates all esignet-mock
+# namespaces so the postInstall hook can copy db-common-secrets into each.
+# Namespaces are created here at priority -16 because the namespace-specific
+# preinstall hooks (esignet-mosipid1/mosipid2/sunbird) only run at priority -14.
+# =============================================================================
+set -euo pipefail
+
+echo "================================================"
+echo "eSignet 1.7.1 - Database Init Pre-install"
+echo "================================================"
+
+for NS in esignet-mock-2-0-0 esignet-mosipid1-2-0-0 esignet-mosipid2-2-0-0 esignet-sunbird-2-0-0; do
+  kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f -
+  kubectl label namespace "$NS" istio-injection=enabled --overwrite
+  echo "Namespace $NS ready."
+done
+
+echo "Database init pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/esignet-misp-onboarder-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/esignet-misp-onboarder-postinstall.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - eSignet MISP Partner Onboarder Post-install
+# =============================================================================
+# Validates onboarding job completion and restarts the esignet deployment
+# so it picks up the new MISP license key.
+# Only used with mosip-identity-plugin (plugin 2).
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+
+echo "================================================"
+echo "eSignet 1.7.1 - MISP Onboarder Post-install"
+echo "================================================"
+
+JOB_STATUS=$(kubectl -n "$ESIGNET_NS" get jobs \
+  -l app.kubernetes.io/instance=esignet-misp-onboarder-2-0-0 \
+  -o jsonpath='{.items[0].status.succeeded}' 2>/dev/null || echo "")
+
+if [ "$JOB_STATUS" = "1" ]; then
+  echo "eSignet MISP partner onboarding completed successfully."
+else
+  echo "WARNING: onboarding job may not have completed. Check logs:"
+  kubectl -n "$ESIGNET_NS" logs -l app.kubernetes.io/instance=esignet-misp-onboarder-2-0-0 --tail=30 2>/dev/null || true
+fi
+
+# Re-enable Istio sidecar injection now that the Job has completed
+kubectl label namespace "$ESIGNET_NS" istio-injection=enabled --overwrite
+echo "Istio injection re-enabled on namespace $ESIGNET_NS."
+
+# Restart config-server first so it reloads the MISP key from the secret,
+# then restart esignet so it fetches the updated config from config-server.
+if kubectl -n "$ESIGNET_NS" get deployment esignet-config-server-2-0-0 &>/dev/null; then
+  kubectl -n "$ESIGNET_NS" rollout restart deployment esignet-config-server-2-0-0
+  kubectl -n "$ESIGNET_NS" rollout status deployment esignet-config-server-2-0-0 --timeout=300s || \
+    echo "WARNING: esignet-config-server-2-0-0 rollout did not complete within timeout." >&2
+  echo "esignet-config-server-2-0-0 restarted."
+else
+  echo "esignet-config-server-2-0-0 deployment not found — skipping restart."
+fi
+
+if kubectl -n "$ESIGNET_NS" get deployment esignet-mock-2-0-0 &>/dev/null; then
+  kubectl -n "$ESIGNET_NS" rollout restart deployment esignet-mock-2-0-0
+  kubectl -n "$ESIGNET_NS" rollout status deployment esignet-mock-2-0-0 --timeout=300s || \
+    echo "WARNING: esignet rollout did not complete within timeout." >&2
+  echo "esignet deployment restarted."
+else
+  echo "esignet deployment not found — skipping restart."
+fi
+
+echo "MISP onboarder post-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/esignet-misp-onboarder-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/esignet-misp-onboarder-preinstall.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - eSignet MISP Partner Onboarder Pre-install
+# =============================================================================
+# Prepares the esignet namespace for the MISP onboarder Job:
+#   - Disables Istio sidecar injection so the Job pod can reach Completed state
+#   - Deletes stale MISP onboarder artifacts from previous runs (idempotency)
+#   - Copies keycloak resources needed by the onboarder Job
+#   - Deletes onboarder-namespace ConfigMap so this release owns it cleanly
+#   - Waits for the esignet pod to be ready before the Job starts
+# Only used with mosip-identity-plugin (plugin 2).
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+KEYCLOAK_NS="keycloak"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - MISP Onboarder Pre-install"
+echo "================================================"
+
+kubectl create namespace "$ESIGNET_NS" --dry-run=client -o yaml | kubectl apply -f -
+
+# Disable Istio sidecar injection — Job pods with sidecars never reach Completed state
+kubectl label namespace "$ESIGNET_NS" istio-injection=disabled --overwrite
+echo "Istio injection disabled on namespace $ESIGNET_NS."
+
+# Delete stale MISP onboarder artifacts from any previous run
+kubectl -n "$ESIGNET_NS" delete configmap esignet-onboarder-config --ignore-not-found=true
+kubectl -n "$ESIGNET_NS" delete secret esignet-onboarder-secrets --ignore-not-found=true
+echo "Stale MISP onboarder artifacts cleaned up."
+
+# Copy keycloak resources needed by the onboarder Job
+$COPY_UTIL configmap keycloak-env-vars "$KEYCLOAK_NS" "$ESIGNET_NS"
+$COPY_UTIL secret keycloak "$KEYCLOAK_NS" "$ESIGNET_NS"
+$COPY_UTIL secret keycloak-client-secrets "$KEYCLOAK_NS" "$ESIGNET_NS"
+
+# Delete onboarder-namespace ConfigMap so this release owns it with the correct annotation
+kubectl -n "$ESIGNET_NS" delete configmap onboarder-namespace --ignore-not-found=true
+
+# Verify eSignet service is running before the onboarder Job starts
+kubectl -n "$ESIGNET_NS" wait --for=condition=ready pod -l app.kubernetes.io/name=esignet --timeout=480s || \
+  { echo "ERROR: eSignet pods not ready after timeout" >&2; exit 1; }
+
+echo "MISP onboarder pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/esignet-mock-rp-onboarder-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/esignet-mock-rp-onboarder-postinstall.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Mock RP OIDC Partner Onboarder Post-install
+# =============================================================================
+# Validates onboarding job completion and restarts mock-relying-party-service
+# so it picks up the newly registered OIDC client.
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Mock RP Onboarder Post-install"
+echo "================================================"
+
+JOB_STATUS=$(kubectl -n "$ESIGNET_NS" get jobs \
+  -l app.kubernetes.io/instance=esignet-mock-rp-onboarder-2-0-0 \
+  -o jsonpath='{.items[0].status.succeeded}' 2>/dev/null || echo "")
+
+if [ "$JOB_STATUS" = "1" ]; then
+  echo "Mock RP OIDC partner onboarding completed successfully."
+else
+  echo "WARNING: onboarding job may not have completed. Check logs:"
+  kubectl -n "$ESIGNET_NS" logs -l app.kubernetes.io/instance=esignet-mock-rp-onboarder-2-0-0 --tail=30 2>/dev/null || true
+fi
+
+# Re-enable Istio sidecar injection now that the Job has completed
+kubectl label namespace "$ESIGNET_NS" istio-injection=enabled --overwrite
+echo "Istio injection re-enabled on namespace $ESIGNET_NS."
+
+# Restart mock-relying-party-service so it picks up the newly onboarded OIDC client
+if kubectl -n "$ESIGNET_NS" get deployment mock-relying-party-service-2-0-0 &>/dev/null; then
+  kubectl -n "$ESIGNET_NS" rollout restart deployment mock-relying-party-service-2-0-0
+  kubectl -n "$ESIGNET_NS" rollout status deployment mock-relying-party-service-2-0-0 --timeout=300s || \
+    echo "WARNING: mock-relying-party-service-2-0-0 rollout did not complete within timeout." >&2
+  echo "mock-relying-party-service-2-0-0 restarted."
+else
+  echo "mock-relying-party-service-2-0-0 deployment not found — skipping restart."
+fi
+
+echo "Mock RP onboarder post-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/esignet-mock-rp-onboarder-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/esignet-mock-rp-onboarder-preinstall.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Mock RP OIDC Partner Onboarder Pre-install
+# =============================================================================
+# Copies required secrets/configmaps to esignet namespace before the
+# partner-onboarder Job runs.
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+KEYCLOAK_NS="keycloak"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Mock RP Onboarder Pre-install"
+echo "================================================"
+
+kubectl create namespace "$ESIGNET_NS" --dry-run=client -o yaml | kubectl apply -f -
+
+# Disable Istio sidecar injection — Job pods with sidecars never reach Completed state
+kubectl label namespace "$ESIGNET_NS" istio-injection=disabled --overwrite
+echo "Istio injection disabled on namespace $ESIGNET_NS."
+
+# Copy keycloak resources needed by the onboarder Job
+$COPY_UTIL configmap keycloak-env-vars "$KEYCLOAK_NS" "$ESIGNET_NS"
+$COPY_UTIL secret keycloak "$KEYCLOAK_NS" "$ESIGNET_NS"
+$COPY_UTIL secret keycloak-client-secrets "$KEYCLOAK_NS" "$ESIGNET_NS"
+
+# Both partner-onboarder charts create a ConfigMap named "onboarder-namespace".
+# Delete it before install so this release owns it with the correct annotation.
+kubectl -n "$ESIGNET_NS" delete configmap onboarder-namespace --ignore-not-found=true
+
+# Verify eSignet service is running
+kubectl -n "$ESIGNET_NS" wait --for=condition=ready pod -l app.kubernetes.io/name=esignet --timeout=480s || \
+  { echo "ERROR: eSignet pods not ready after timeout" >&2; exit 1; }
+
+echo "Mock RP onboarder pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/esignet-mosipid1-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/esignet-mosipid1-preinstall.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - eSignet MOSIPID1 Service Pre-install
+# =============================================================================
+# Wrapper: sets ESIGNET_NS=esignet-mosipid1, runs base esignet preinstall (copies
+# postgres + redis config/secrets), then creates esignet-captcha-mosipid1-2-0-0 secret
+# in the captcha namespace from workflow env vars, copies it to esignet-mosipid1,
+# and patches the captcha deployment with the MOSIPID1 secret key.
+# =============================================================================
+set -euo pipefail
+
+export ESIGNET_NS="esignet-mosipid1-2-0-0"
+CAPTCHA_NS="captcha"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+CAPTCHA_SITE_KEY="${ESIGNET_MOSIPID1_CAPTCHA_SITE_KEY:?ERROR: ESIGNET_MOSIPID1_CAPTCHA_SITE_KEY must be set}"
+CAPTCHA_SECRET_KEY="${ESIGNET_MOSIPID1_CAPTCHA_SECRET_KEY:?ERROR: ESIGNET_MOSIPID1_CAPTCHA_SECRET_KEY must be set}"
+MOSIPID1_POSTGRES_PASS="${MOSIPID1_POSTGRES_PASSWORD:?ERROR: MOSIPID1_POSTGRES_PASSWORD must be set}"
+MOSIPID1_KC_ADMIN_PASS="${MOSIPID1_KEYCLOAK_ADMIN_PASSWORD:?ERROR: MOSIPID1_KEYCLOAK_ADMIN_PASSWORD must be set}"
+
+"$WORKDIR/hooks/esignet-standalone-2.0.0/esignet-preinstall.sh"
+
+# Create MOSIPID1-specific esignet-global — same domain_name, but esignet/signup hosts differ
+kubectl -n "$ESIGNET_NS" create configmap esignet-global \
+  --from-literal=installation-domain="${domain_name}" \
+  --from-literal=mosip-api-host="api.${domain_name}" \
+  --from-literal=mosip-api-internal-host="api-internal.${domain_name}" \
+  --from-literal=mosip-esignet-host="esignet-mosipid1-2-0-0.${domain_name}" \
+  --from-literal=mosip-iam-external-host="iam.${domain_name}" \
+  --from-literal=mosip-kafka-host="kafka.${domain_name}" \
+  --from-literal=mosip-postgres-host="postgres.${domain_name}" \
+  --from-literal=mosip-signup-host="signup-mosipid1-2-0-0.${domain_name}" \
+  --from-literal=mosip-smtp-host="smtp-2-0-0.${domain_name}" \
+  --from-literal=mosip-version="develop" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# Override postgres-config with MOSIPID1-specific DB values (2.0.0: isolated database)
+kubectl -n "$ESIGNET_NS" patch configmap postgres-config --type merge \
+  -p '{"data":{"database-name":"mosip_esignet_mosipid1_2_0_0","database-username":"esignetuser_mosipid1_2_0_0"}}'
+
+# Create esignet-misp-onboarder-key placeholder — real value written by MISP onboarder.
+if ! kubectl -n "$ESIGNET_NS" get secret esignet-misp-onboarder-key &>/dev/null; then
+  kubectl -n "$ESIGNET_NS" create secret generic esignet-misp-onboarder-key \
+    --from-literal=mosip-esignet-misp-key=""
+  echo "esignet-misp-onboarder-key placeholder created in $ESIGNET_NS"
+fi
+
+echo "Creating esignet-captcha-mosipid1-2-0-0 secret in $CAPTCHA_NS namespace"
+kubectl -n "$CAPTCHA_NS" create secret generic esignet-captcha-mosipid1-2-0-0 \
+  --from-literal=esignet-captcha-site-key="$CAPTCHA_SITE_KEY" \
+  --from-literal=esignet-captcha-secret-key="$CAPTCHA_SECRET_KEY" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Copying esignet-captcha-mosipid1-2-0-0 secret from $CAPTCHA_NS to $ESIGNET_NS"
+$COPY_UTIL secret esignet-captcha-mosipid1-2-0-0 "$CAPTCHA_NS" "$ESIGNET_NS"
+
+echo "Patching captcha deployment with ESIGNETMOSIPID1 secret key"
+ENV_VAR_EXISTS=$(kubectl -n "$CAPTCHA_NS" get deployment captcha \
+  -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNETMOSIPID1_2_0_0')].name}" 2>/dev/null || echo "")
+if [[ -z "$ENV_VAR_EXISTS" ]]; then
+  kubectl patch deployment -n "$CAPTCHA_NS" captcha --type='json' \
+    -p='[{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNETMOSIPID1_2_0_0", "valueFrom": {"secretKeyRef": {"name": "esignet-captcha-mosipid1-2-0-0", "key": "esignet-captcha-secret-key"}}}}]'
+else
+  echo "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNETMOSIPID1_2_0_0 already exists."
+fi
+
+# --- postgres-postgresql-mosipid1 secret (MOSIPID1 remote postgres password) ---
+echo "Creating postgres-postgresql-mosipid1 secret in $ESIGNET_NS"
+kubectl -n "$ESIGNET_NS" create secret generic postgres-postgresql-mosipid1 \
+  --from-literal=postgres-password="${MOSIPID1_POSTGRES_PASS}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# --- keycloak-host-mosipid1 CM (external URL points to MOSIPID1 Keycloak) ---
+echo "Creating keycloak-host-mosipid1 configmap in $ESIGNET_NS"
+kubectl -n "$ESIGNET_NS" create configmap keycloak-host-mosipid1 \
+  --from-literal=keycloak-external-host="iam.${mosipid1_domain_name}" \
+  --from-literal=keycloak-external-url="https://iam.${mosipid1_domain_name}" \
+  --from-literal=keycloak-internal-host="keycloak.keycloak" \
+  --from-literal=keycloak-internal-service-url="http://keycloak.keycloak/auth/" \
+  --from-literal=keycloak-internal-url="http://keycloak.keycloak" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# --- keycloak-client-secrets-mosipid1: fetch all confidential clients from MOSIPID1 Keycloak ---
+KC_HOST="iam.${mosipid1_domain_name}"
+REALM="mosip"
+
+echo "Fetching admin token from $KC_HOST"
+TOKEN_RESPONSE=$(curl -sf -X POST \
+  "https://${KC_HOST}/auth/realms/master/protocol/openid-connect/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=password&client_id=admin-cli&username=admin&password=${MOSIPID1_KC_ADMIN_PASS}")
+ADMIN_TOKEN=$(echo "$TOKEN_RESPONSE" | jq -r '.access_token')
+if [[ -z "$ADMIN_TOKEN" || "$ADMIN_TOKEN" == "null" ]]; then
+  echo "❌ Failed to get admin token from $KC_HOST" >&2; exit 1
+fi
+echo "✓ Admin token obtained"
+
+echo "Fetching all clients from realm $REALM on $KC_HOST"
+CLIENTS=$(curl -sf \
+  "https://${KC_HOST}/auth/admin/realms/${REALM}/clients?max=500" \
+  -H "Authorization: Bearer $ADMIN_TOKEN")
+
+SECRET_ARGS=()
+while IFS= read -r client_json; do
+  client_id=$(echo "$client_json" | jq -r '.clientId')
+  uuid=$(echo "$client_json"      | jq -r '.id')
+  auth_type=$(echo "$client_json" | jq -r '.clientAuthenticatorType')
+  is_public=$(echo "$client_json" | jq -r '.publicClient')
+  [[ "$auth_type" != "client-secret" || "$is_public" == "true" ]] && continue
+  secret_val=$(curl -sf \
+    "https://${KC_HOST}/auth/admin/realms/${REALM}/clients/${uuid}/client-secret" \
+    -H "Authorization: Bearer $ADMIN_TOKEN" | jq -r '.value // empty')
+  [[ -z "$secret_val" || "$secret_val" == "null" ]] && continue
+  key=$(echo "$client_id" | tr '-' '_')_secret
+  SECRET_ARGS+=("--from-literal=${key}=${secret_val}")
+  echo "  ✓ $client_id"
+done < <(echo "$CLIENTS" | jq -c '.[]')
+
+if [[ ${#SECRET_ARGS[@]} -eq 0 ]]; then
+  echo "❌ No client secrets fetched from MOSIPID1 Keycloak" >&2; exit 1
+fi
+echo "Creating keycloak-client-secrets-mosipid1 in $ESIGNET_NS (${#SECRET_ARGS[@]} clients)"
+kubectl -n "$ESIGNET_NS" create secret generic keycloak-client-secrets-mosipid1 \
+  "${SECRET_ARGS[@]}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+echo "✓ keycloak-client-secrets-mosipid1 created"
+
+echo "eSignet MOSIPID1 pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/esignet-mosipid2-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/esignet-mosipid2-preinstall.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - eSignet MOSIPID2 Service Pre-install
+# =============================================================================
+# Wrapper: sets ESIGNET_NS=esignet-mosipid2, runs base esignet preinstall (copies
+# postgres + redis config/secrets), then creates esignet-captcha-mosipid2-2-0-0 secret
+# in the captcha namespace from workflow env vars, copies it to esignet-mosipid2,
+# and patches the captcha deployment with the MOSIPID2 secret key.
+# =============================================================================
+set -euo pipefail
+
+export ESIGNET_NS="esignet-mosipid2-2-0-0"
+CAPTCHA_NS="captcha"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+CAPTCHA_SITE_KEY="${ESIGNET_MOSIPID2_CAPTCHA_SITE_KEY:?ERROR: ESIGNET_MOSIPID2_CAPTCHA_SITE_KEY must be set}"
+CAPTCHA_SECRET_KEY="${ESIGNET_MOSIPID2_CAPTCHA_SECRET_KEY:?ERROR: ESIGNET_MOSIPID2_CAPTCHA_SECRET_KEY must be set}"
+MOSIPID2_POSTGRES_PASS="${MOSIPID2_POSTGRES_PASSWORD:?ERROR: MOSIPID2_POSTGRES_PASSWORD must be set}"
+MOSIPID2_KC_ADMIN_PASS="${MOSIPID2_KEYCLOAK_ADMIN_PASSWORD:?ERROR: MOSIPID2_KEYCLOAK_ADMIN_PASSWORD must be set}"
+
+"$WORKDIR/hooks/esignet-standalone-2.0.0/esignet-preinstall.sh"
+
+# Create MOSIPID2-specific esignet-global — same domain_name, but esignet/signup hosts differ
+kubectl -n "$ESIGNET_NS" create configmap esignet-global \
+  --from-literal=installation-domain="${domain_name}" \
+  --from-literal=mosip-api-host="api.${domain_name}" \
+  --from-literal=mosip-api-internal-host="api-internal.${domain_name}" \
+  --from-literal=mosip-esignet-host="esignet-mosipid2-2-0-0.${domain_name}" \
+  --from-literal=mosip-iam-external-host="iam.${domain_name}" \
+  --from-literal=mosip-kafka-host="kafka.${domain_name}" \
+  --from-literal=mosip-postgres-host="postgres.${domain_name}" \
+  --from-literal=mosip-signup-host="signup-mosipid2-2-0-0.${domain_name}" \
+  --from-literal=mosip-smtp-host="smtp-2-0-0.${domain_name}" \
+  --from-literal=mosip-version="develop" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# Override postgres-config with MOSIPID2-specific DB values (2.0.0: isolated database)
+kubectl -n "$ESIGNET_NS" patch configmap postgres-config --type merge \
+  -p '{"data":{"database-name":"mosip_esignet_mosipid2_2_0_0","database-username":"esignetuser_mosipid2_2_0_0"}}'
+
+# Create esignet-misp-onboarder-key placeholder — real value written by MISP onboarder.
+if ! kubectl -n "$ESIGNET_NS" get secret esignet-misp-onboarder-key &>/dev/null; then
+  kubectl -n "$ESIGNET_NS" create secret generic esignet-misp-onboarder-key \
+    --from-literal=mosip-esignet-misp-key=""
+  echo "esignet-misp-onboarder-key placeholder created in $ESIGNET_NS"
+fi
+
+echo "Creating esignet-captcha-mosipid2-2-0-0 secret in $CAPTCHA_NS namespace"
+kubectl -n "$CAPTCHA_NS" create secret generic esignet-captcha-mosipid2-2-0-0 \
+  --from-literal=esignet-captcha-site-key="$CAPTCHA_SITE_KEY" \
+  --from-literal=esignet-captcha-secret-key="$CAPTCHA_SECRET_KEY" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Copying esignet-captcha-mosipid2-2-0-0 secret from $CAPTCHA_NS to $ESIGNET_NS"
+$COPY_UTIL secret esignet-captcha-mosipid2-2-0-0 "$CAPTCHA_NS" "$ESIGNET_NS"
+
+echo "Patching captcha deployment with ESIGNETMOSIPID2 secret key"
+ENV_VAR_EXISTS=$(kubectl -n "$CAPTCHA_NS" get deployment captcha \
+  -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNETMOSIPID2_2_0_0')].name}" 2>/dev/null || echo "")
+if [[ -z "$ENV_VAR_EXISTS" ]]; then
+  kubectl patch deployment -n "$CAPTCHA_NS" captcha --type='json' \
+    -p='[{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNETMOSIPID2_2_0_0", "valueFrom": {"secretKeyRef": {"name": "esignet-captcha-mosipid2-2-0-0", "key": "esignet-captcha-secret-key"}}}}]'
+else
+  echo "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNETMOSIPID2_2_0_0 already exists."
+fi
+
+# --- postgres-postgresql-mosipid2 secret (MOSIPID2 remote postgres password) ---
+echo "Creating postgres-postgresql-mosipid2 secret in $ESIGNET_NS"
+kubectl -n "$ESIGNET_NS" create secret generic postgres-postgresql-mosipid2 \
+  --from-literal=postgres-password="${MOSIPID2_POSTGRES_PASS}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# --- keycloak-host-mosipid2 CM (external URL points to MOSIPID2 Keycloak) ---
+echo "Creating keycloak-host-mosipid2 configmap in $ESIGNET_NS"
+kubectl -n "$ESIGNET_NS" create configmap keycloak-host-mosipid2 \
+  --from-literal=keycloak-external-host="iam.${mosipid2_domain_name}" \
+  --from-literal=keycloak-external-url="https://iam.${mosipid2_domain_name}" \
+  --from-literal=keycloak-internal-host="keycloak.keycloak" \
+  --from-literal=keycloak-internal-service-url="http://keycloak.keycloak/auth/" \
+  --from-literal=keycloak-internal-url="http://keycloak.keycloak" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# --- keycloak-client-secrets-mosipid2: fetch all confidential clients from MOSIPID2 Keycloak ---
+KC_HOST="iam.${mosipid2_domain_name}"
+REALM="mosip"
+
+echo "Fetching admin token from $KC_HOST"
+TOKEN_RESPONSE=$(curl -sf -X POST \
+  "https://${KC_HOST}/auth/realms/master/protocol/openid-connect/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=password&client_id=admin-cli&username=admin&password=${MOSIPID2_KC_ADMIN_PASS}")
+ADMIN_TOKEN=$(echo "$TOKEN_RESPONSE" | jq -r '.access_token')
+if [[ -z "$ADMIN_TOKEN" || "$ADMIN_TOKEN" == "null" ]]; then
+  echo "❌ Failed to get admin token from $KC_HOST" >&2; exit 1
+fi
+echo "✓ Admin token obtained"
+
+echo "Fetching all clients from realm $REALM on $KC_HOST"
+CLIENTS=$(curl -sf \
+  "https://${KC_HOST}/auth/admin/realms/${REALM}/clients?max=500" \
+  -H "Authorization: Bearer $ADMIN_TOKEN")
+
+SECRET_ARGS=()
+while IFS= read -r client_json; do
+  client_id=$(echo "$client_json" | jq -r '.clientId')
+  uuid=$(echo "$client_json"      | jq -r '.id')
+  auth_type=$(echo "$client_json" | jq -r '.clientAuthenticatorType')
+  is_public=$(echo "$client_json" | jq -r '.publicClient')
+  [[ "$auth_type" != "client-secret" || "$is_public" == "true" ]] && continue
+  secret_val=$(curl -sf \
+    "https://${KC_HOST}/auth/admin/realms/${REALM}/clients/${uuid}/client-secret" \
+    -H "Authorization: Bearer $ADMIN_TOKEN" | jq -r '.value // empty')
+  [[ -z "$secret_val" || "$secret_val" == "null" ]] && continue
+  key=$(echo "$client_id" | tr '-' '_')_secret
+  SECRET_ARGS+=("--from-literal=${key}=${secret_val}")
+  echo "  ✓ $client_id"
+done < <(echo "$CLIENTS" | jq -c '.[]')
+
+if [[ ${#SECRET_ARGS[@]} -eq 0 ]]; then
+  echo "❌ No client secrets fetched from MOSIPID2 Keycloak" >&2; exit 1
+fi
+echo "Creating keycloak-client-secrets-mosipid2 in $ESIGNET_NS (${#SECRET_ARGS[@]} clients)"
+kubectl -n "$ESIGNET_NS" create secret generic keycloak-client-secrets-mosipid2 \
+  "${SECRET_ARGS[@]}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+echo "✓ keycloak-client-secrets-mosipid2 created"
+
+echo "eSignet MOSIPID2 pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/esignet-postinstall-keycloak-init.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/esignet-postinstall-keycloak-init.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Post-install hook for esignet-keycloak-init (eSignet 1.7.1 standalone)
+# The chart runs in keycloak ns and creates keycloak-host CM and
+# keycloak-client-secrets secret there. This hook fans those resources out to
+# all esignet-mock namespaces so every esignet-mock instance can reference them without
+# cross-namespace lookups.
+set -euo pipefail
+
+KEYCLOAK_NS="keycloak"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+# All esignet-mock namespaces that need keycloak resources
+ESIGNET_NAMESPACES=(esignet-mock-2-0-0 esignet-mosipid1-2-0-0 esignet-mosipid2-2-0-0 esignet-sunbird-2-0-0)
+
+echo "================================================"
+echo "eSignet 1.7.1 - Keycloak Init Post-install"
+echo "================================================"
+
+echo "Sharing keycloak resources from $KEYCLOAK_NS to all esignet-mock-2-0-0 namespaces"
+for NS_TARGET in "${ESIGNET_NAMESPACES[@]}"; do
+  if ! kubectl get namespace "$NS_TARGET" &>/dev/null; then
+    echo "Namespace $NS_TARGET does not exist, skipping"
+    continue
+  fi
+  echo "  → $NS_TARGET"
+  $COPY_UTIL configmap keycloak-host        "$KEYCLOAK_NS" "$NS_TARGET"
+  $COPY_UTIL configmap keycloak-env-vars    "$KEYCLOAK_NS" "$NS_TARGET"
+  $COPY_UTIL secret    keycloak             "$KEYCLOAK_NS" "$NS_TARGET"
+  $COPY_UTIL secret    keycloak-client-secrets "$KEYCLOAK_NS" "$NS_TARGET"
+done
+
+echo "Post-install setup complete."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/esignet-preinstall-keycloak-init.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/esignet-preinstall-keycloak-init.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Pre-install hook for esignet-keycloak-init (eSignet 1.7.1 standalone)
+# Runs in the keycloak namespace — all required resources (keycloak secret,
+# keycloak-env-vars CM) are already present from the bitnami keycloak chart.
+# The chart creates keycloak-host CM and keycloak-client-secrets in keycloak ns.
+# We clean up the previous release and chart-managed resources so the fresh
+# helm install can recreate them cleanly.
+set -euo pipefail
+
+KEYCLOAK_NS="keycloak"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Keycloak Init Pre-install"
+echo "================================================"
+
+# Delete previous releases so helm install starts fresh.
+# keycloak-host CM and keycloak-client-secrets secret are helm-managed — helm delete
+# removes them automatically; no manual kubectl delete needed here.
+helm -n "$KEYCLOAK_NS" delete esignet-keycloak-init 2>/dev/null || true
+# Migration: remove old release from esignet ns if it was deployed there previously
+helm -n esignet delete esignet-keycloak-init 2>/dev/null || true
+
+# Fetch existing client secrets from keycloak namespace for DSF ${VAR} substitution.
+# Empty on fresh install — helm chart generates them; existing values preserved on re-run.
+PMS_CLIENT_SECRET_KEY="mosip_pms_client_secret"
+MPARTNER_DEFAULT_AUTH_SECRET_KEY="mpartner_default_auth_secret"
+IDA_CLIENT_SECRET_KEY="mosip_ida_client_secret"
+DEPLOYMENT_CLIENT_SECRET_KEY="mosip_deployment_client_secret"
+MPARTNER_DEFAULT_MOBILE_SECRET_KEY="mpartner_default_mobile_secret"
+
+PMS_CLIENT_SECRET_VALUE="$(kubectl -n "$KEYCLOAK_NS" get secret keycloak-client-secrets \
+  -o jsonpath="{.data.${PMS_CLIENT_SECRET_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || echo "")"
+export PMS_CLIENT_SECRET_KEY PMS_CLIENT_SECRET_VALUE
+
+MPARTNER_DEFAULT_AUTH_SECRET_VALUE="$(kubectl -n "$KEYCLOAK_NS" get secret keycloak-client-secrets \
+  -o jsonpath="{.data.${MPARTNER_DEFAULT_AUTH_SECRET_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || echo "")"
+export MPARTNER_DEFAULT_AUTH_SECRET_KEY MPARTNER_DEFAULT_AUTH_SECRET_VALUE
+
+IDA_CLIENT_SECRET_VALUE="$(kubectl -n "$KEYCLOAK_NS" get secret keycloak-client-secrets \
+  -o jsonpath="{.data.${IDA_CLIENT_SECRET_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || echo "")"
+export IDA_CLIENT_SECRET_KEY IDA_CLIENT_SECRET_VALUE
+
+DEPLOYMENT_CLIENT_SECRET_VALUE="$(kubectl -n "$KEYCLOAK_NS" get secret keycloak-client-secrets \
+  -o jsonpath="{.data.${DEPLOYMENT_CLIENT_SECRET_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || echo "")"
+export DEPLOYMENT_CLIENT_SECRET_KEY DEPLOYMENT_CLIENT_SECRET_VALUE
+
+MPARTNER_DEFAULT_MOBILE_SECRET_VALUE="$(kubectl -n "$KEYCLOAK_NS" get secret keycloak-client-secrets \
+  -o jsonpath="{.data.${MPARTNER_DEFAULT_MOBILE_SECRET_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || echo "")"
+export MPARTNER_DEFAULT_MOBILE_SECRET_KEY MPARTNER_DEFAULT_MOBILE_SECRET_VALUE
+
+echo "Pre-install setup complete. Helmsman will now deploy esignet-keycloak-init chart."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/esignet-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/esignet-preinstall.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - eSignet Service Pre-install
+# =============================================================================
+# Based on: deploy/esignet-mock/install.sh
+# Prepares esignet-mock namespace with postgres and redis configmaps/secrets
+# before eSignet helm chart deployment.
+#
+# softhsm-esignet-mock deploys in the esignet-mock namespace (priority -14, before
+# esignet-mock at -12), so esignet-softhsm-share is already present — no copy needed.
+#
+# Environment Variables:
+#   ESIGNET_NS   - eSignet namespace (default: esignet-mock)
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+POSTGRES_NS="postgres"
+REDIS_NS="redis"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - eSignet Service Pre-install"
+echo "================================================"
+
+# --- Step 1: Ensure esignet-mock namespace exists with Istio ---
+echo "Setting up $ESIGNET_NS namespace"
+kubectl create namespace "$ESIGNET_NS" --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace "$ESIGNET_NS" istio-injection=enabled --overwrite
+
+# --- Step 2: Update helm repos ---
+helm repo add mosip https://mosip.github.io/mosip-helm || true
+helm repo update
+
+# --- Step 3: Copy configmaps from other namespaces ---
+# All external services (postgres, redis) are guaranteed deployed before
+# esignet-mock-dsf runs.
+echo "Copying postgres-config configmap from $POSTGRES_NS"
+$COPY_UTIL configmap postgres-config "$POSTGRES_NS" "$ESIGNET_NS"
+
+# Override postgres-config with 2.0.0-specific DB values (isolated database)
+kubectl -n "$ESIGNET_NS" patch configmap postgres-config --type merge \
+  -p '{"data":{"database-name":"mosip_esignet_2_0_0","database-username":"esignetuser_2_0_0"}}'
+
+echo "Copying redis-config configmap from $REDIS_NS"
+$COPY_UTIL configmap redis-config "$REDIS_NS" "$ESIGNET_NS"
+
+# --- Step 4: Copy secrets from other namespaces ---
+echo "Copying postgres-postgresql secret from $POSTGRES_NS"
+$COPY_UTIL secret postgres-postgresql "$POSTGRES_NS" "$ESIGNET_NS"
+
+echo "Copying redis secret from $REDIS_NS"
+$COPY_UTIL secret redis "$REDIS_NS" "$ESIGNET_NS"
+
+# db-common-secrets is normally fanned out by esignet-db-postinstall.sh (part of the
+# shared external-dsf.yaml postgres-init-esignet release), but that hook's namespace
+# loop only covers the original esignet-standalone namespaces. Copy it directly here
+# so the 2.0.0 namespace is self-sufficient without touching the shared hook.
+echo "Copying db-common-secrets secret from $POSTGRES_NS"
+$COPY_UTIL secret db-common-secrets "$POSTGRES_NS" "$ESIGNET_NS"
+
+echo "eSignet pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/esignet-sunbird-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/esignet-sunbird-preinstall.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - eSignet Sunbird Service Pre-install
+# =============================================================================
+# Wrapper: sets ESIGNET_NS=esignet-sunbird, runs base esignet preinstall (copies
+# postgres + redis config/secrets), then creates esignet-captcha-sunbird-2-0-0 secret
+# in the captcha namespace from workflow env vars, copies it to esignet-sunbird,
+# and patches the captcha deployment with the Sunbird secret key.
+# =============================================================================
+set -euo pipefail
+
+export ESIGNET_NS="esignet-sunbird-2-0-0"
+CAPTCHA_NS="captcha"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+CAPTCHA_SITE_KEY="${ESIGNET_SUNBIRD_CAPTCHA_SITE_KEY:?ERROR: ESIGNET_SUNBIRD_CAPTCHA_SITE_KEY must be set}"
+CAPTCHA_SECRET_KEY="${ESIGNET_SUNBIRD_CAPTCHA_SECRET_KEY:?ERROR: ESIGNET_SUNBIRD_CAPTCHA_SECRET_KEY must be set}"
+
+"$WORKDIR/hooks/esignet-standalone-2.0.0/esignet-preinstall.sh"
+
+# Create Sunbird-specific esignet-global — same domain_name, but esignet/signup hosts differ
+kubectl -n "$ESIGNET_NS" create configmap esignet-global \
+  --from-literal=installation-domain="${domain_name}" \
+  --from-literal=mosip-api-host="api.${domain_name}" \
+  --from-literal=mosip-api-internal-host="api-internal.${domain_name}" \
+  --from-literal=mosip-esignet-host="esignet-sunbird-2-0-0.${domain_name}" \
+  --from-literal=mosip-iam-external-host="iam.${domain_name}" \
+  --from-literal=mosip-kafka-host="kafka.${domain_name}" \
+  --from-literal=mosip-postgres-host="postgres.${domain_name}" \
+  --from-literal=mosip-signup-host="signup-sunbird-2-0-0.${domain_name}" \
+  --from-literal=mosip-smtp-host="smtp-2-0-0.${domain_name}" \
+  --from-literal=mosip-version="develop" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# Override postgres-config with Sunbird-specific DB values
+kubectl -n "$ESIGNET_NS" patch configmap postgres-config --type merge \
+  -p '{"data":{"database-name":"mosip_esignet_sunbird_2_0_0","database-username":"esignetuser_sunbird_2_0_0"}}'
+
+# Create esignet-misp-onboarder-key placeholder — real value written by MISP onboarder.
+if ! kubectl -n "$ESIGNET_NS" get secret esignet-misp-onboarder-key &>/dev/null; then
+  kubectl -n "$ESIGNET_NS" create secret generic esignet-misp-onboarder-key \
+    --from-literal=mosip-esignet-misp-key=""
+  echo "esignet-misp-onboarder-key placeholder created in $ESIGNET_NS"
+fi
+
+echo "Creating esignet-captcha-sunbird-2-0-0 secret in $CAPTCHA_NS namespace"
+kubectl -n "$CAPTCHA_NS" create secret generic esignet-captcha-sunbird-2-0-0 \
+  --from-literal=esignet-captcha-site-key="$CAPTCHA_SITE_KEY" \
+  --from-literal=esignet-captcha-secret-key="$CAPTCHA_SECRET_KEY" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Copying esignet-captcha-sunbird-2-0-0 secret from $CAPTCHA_NS to $ESIGNET_NS"
+$COPY_UTIL secret esignet-captcha-sunbird-2-0-0 "$CAPTCHA_NS" "$ESIGNET_NS"
+
+echo "Patching captcha deployment with ESIGNETSUNBIRD secret key"
+ENV_VAR_EXISTS=$(kubectl -n "$CAPTCHA_NS" get deployment captcha \
+  -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNETSUNBIRD_2_0_0')].name}" 2>/dev/null || echo "")
+if [[ -z "$ENV_VAR_EXISTS" ]]; then
+  kubectl patch deployment -n "$CAPTCHA_NS" captcha --type='json' \
+    -p='[{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNETSUNBIRD_2_0_0", "valueFrom": {"secretKeyRef": {"name": "esignet-captcha-sunbird-2-0-0", "key": "esignet-captcha-secret-key"}}}}]'
+else
+  echo "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_ESIGNETSUNBIRD_2_0_0 already exists."
+fi
+
+echo "eSignet Sunbird pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/kafka-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/kafka-postinstall.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Kafka Post-install
+# =============================================================================
+# Based on: deploy/install-prereq.sh (kafka section)
+# Creates kafka-config configmap in esignet namespace after Kafka deployment.
+#
+# Environment Variables:
+#   KAFKA_URL    - Kafka bootstrap servers URL (default: internal kafka cluster)
+#   ESIGNET_NS   - eSignet namespace (default: esignet)
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+KAFKA_URL="${KAFKA_URL:-kafka-0.kafka-headless.kafka.svc.cluster.local:9092,kafka-1.kafka-headless.kafka.svc.cluster.local:9092,kafka-2.kafka-headless.kafka.svc.cluster.local:9092}"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Kafka Post-install"
+echo "================================================"
+
+# --- Create kafka-config configmap in esignet namespace ---
+# Source: deploy/install-prereq.sh - kafka configmap creation
+echo "Creating kafka-config configmap in $ESIGNET_NS namespace"
+kubectl -n "$ESIGNET_NS" create configmap kafka-config \
+  --from-literal=SPRING_KAFKA_BOOTSTRAP-SERVERS="$KAFKA_URL" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Kafka post-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/kernel-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/kernel-preinstall.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Kernel Services Pre-install
+# =============================================================================
+# Based on: esignet-signup/deploy/kernel/install.sh
+# Creates kernel namespace, domain-config configmap, and optionally copies
+# artifactory-share and config-server-share configmaps if available.
+#
+# This script is idempotent — safe to run multiple times (used as preInstall
+# for authmanager, auditmanager, and otpmanager which run in parallel).
+#
+# Environment Variables:
+#   MOSIP_API_HOST           - External API host (e.g. api.sandbox.xyz.net)
+#   MOSIP_API_INTERNAL_HOST  - Internal API host (e.g. api-internal.sandbox.xyz.net)
+# =============================================================================
+set -euo pipefail
+
+KERNEL_NS="kernel-2-0-0"
+API_HOST="${MOSIP_API_HOST:-}"
+API_INTERNAL_HOST="${MOSIP_API_INTERNAL_HOST:-}"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Kernel Pre-install"
+echo "================================================"
+
+# --- Step 1: Ensure kernel namespace exists with istio ---
+kubectl create namespace "$KERNEL_NS" --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace "$KERNEL_NS" istio-injection=enabled --overwrite
+
+# --- Step 2: Create domain-config configmap ---
+echo "Creating domain-config configmap in $KERNEL_NS"
+kubectl -n "$KERNEL_NS" create configmap domain-config \
+  --from-literal=mosip-api-host="$API_HOST" \
+  --from-literal=mosip-api-internal-host="$API_INTERNAL_HOST" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# --- Step 3: Copy optional configmaps from artifactory and config-server ---
+$COPY_UTIL configmap artifactory-share artifactory "$KERNEL_NS" 2>/dev/null || \
+  echo "WARNING: artifactory-share not found in artifactory namespace, skipping"
+$COPY_UTIL configmap config-server-share config-server "$KERNEL_NS" 2>/dev/null || \
+  echo "WARNING: config-server-share not found in config-server namespace, skipping"
+
+echo "Kernel pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/keycloak-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/keycloak-postinstall.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Keycloak Post-install (Keycloak Init)
+# =============================================================================
+# Based on: deploy/keycloak/keycloak-init.sh + deploy/initialise-prereq.sh
+# Copies keycloak configmaps/secrets to esignet namespace and runs
+# keycloak-init helm chart to create eSignet-specific clients and roles.
+#
+# Environment Variables:
+#   INSTALLATION_DOMAIN      - Base domain (default: sandbox.xyz.net)
+#   KEYCLOAK_INIT_VERSION    - keycloak-init chart version (default: 12.0.2)
+#   ESIGNET_NS               - eSignet namespace (default: esignet)
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+KEYCLOAK_NS="keycloak"
+CHART_VERSION="${KEYCLOAK_INIT_VERSION:-12.0.2}"
+INSTALLATION_DOMAIN="${INSTALLATION_DOMAIN:-sandbox.xyz.net}"
+IAMHOST_URL="iam.${INSTALLATION_DOMAIN}"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Keycloak Post-install (Init)"
+echo "================================================"
+
+# --- Step 1: Copy keycloak configmaps and secrets to esignet namespace ---
+echo "Copying keycloak configmaps and secrets to $ESIGNET_NS namespace"
+
+$COPY_UTIL configmap keycloak-host "$KEYCLOAK_NS" "$ESIGNET_NS" 2>/dev/null || {
+  echo "keycloak-host not found in $KEYCLOAK_NS - creating directly"
+  kubectl -n "$ESIGNET_NS" create configmap keycloak-host \
+    --from-literal=keycloak-external-url="https://$IAMHOST_URL" \
+    --from-literal=keycloak-internal-url="http://keycloak.$KEYCLOAK_NS" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
+
+$COPY_UTIL configmap keycloak-env-vars "$KEYCLOAK_NS" "$ESIGNET_NS" 2>/dev/null || \
+  echo "WARNING: keycloak-env-vars not found in $KEYCLOAK_NS"
+
+$COPY_UTIL secret keycloak "$KEYCLOAK_NS" "$ESIGNET_NS" 2>/dev/null || \
+  echo "WARNING: keycloak secret not found in $KEYCLOAK_NS"
+
+# --- Step 2: Read existing client secrets if any ---
+echo "Checking for existing keycloak-client-secrets"
+HELM_SET_SECRETS=()
+
+escape_helm_value() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//,/\\,}"
+  value="${value//=/\\=}"
+  printf '%s' "$value"
+}
+
+declare -A SECRET_KEYS=(
+  ["mosip_pms_client_secret"]="0"
+  ["mpartner_default_auth_secret"]="1"
+  ["mosip_ida_client_secret"]="2"
+  ["mosip_deployment_client_secret"]="3"
+  ["mpartner_default_mobile_secret"]="4"
+)
+
+if kubectl -n "$KEYCLOAK_NS" get secret keycloak-client-secrets &>/dev/null; then
+  echo "Found existing keycloak-client-secrets. Preserving client secrets."
+  for key in "${!SECRET_KEYS[@]}"; do
+    idx="${SECRET_KEYS[$key]}"
+    val=$(kubectl -n "$KEYCLOAK_NS" get secret keycloak-client-secrets \
+      -o jsonpath="{.data.$key}" 2>/dev/null | base64 -d 2>/dev/null || echo "")
+    if [[ -n "$val" ]]; then
+      HELM_SET_SECRETS+=(
+        --set-string "clientSecrets[$idx].name=$key"
+        --set-string "clientSecrets[$idx].secret=$(escape_helm_value "$val")"
+      )
+    fi
+  done
+else
+  echo "No existing keycloak-client-secrets found. Fresh install."
+fi
+
+# --- Step 3: Run keycloak-init helm chart ---
+echo "Installing esignet-keycloak-init"
+helm repo add mosip https://mosip.github.io/mosip-helm || true
+helm repo update
+
+kubectl -n "$ESIGNET_NS" delete secret --ignore-not-found=true keycloak-client-secrets
+helm -n "$ESIGNET_NS" delete esignet-keycloak-init 2>/dev/null || true
+
+helm -n "$ESIGNET_NS" install esignet-keycloak-init mosip/keycloak-init \
+  ${HELM_SET_SECRETS[@]+"${HELM_SET_SECRETS[@]}"} \
+  --set keycloak.realms.mosip.realm_config.attributes.frontendUrl="https://$IAMHOST_URL/auth" \
+  --set keycloakInternalHost="keycloak.$KEYCLOAK_NS" \
+  --set keycloakExternalHost="$IAMHOST_URL" \
+  --version "$CHART_VERSION" --wait --wait-for-jobs
+
+# --- Step 4: Sync updated client secrets back to keycloak namespace ---
+echo "Syncing keycloak-client-secrets back to $KEYCLOAK_NS namespace"
+if kubectl -n "$ESIGNET_NS" get secret keycloak-client-secrets &>/dev/null; then
+  $COPY_UTIL secret keycloak-client-secrets "$ESIGNET_NS" "$KEYCLOAK_NS"
+  echo "keycloak-client-secrets synced to $KEYCLOAK_NS namespace."
+fi
+
+echo "Keycloak post-install (init) completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/mock-identity-init-db.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/mock-identity-init-db.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Mock Identity System DB Init Pre-install
+# =============================================================================
+# Based on: esignet-mock-services/deploy/postgres/init_db.sh
+# Ensures postgres-postgresql secret is present in the esignet namespace
+# before postgres-init-mock-identity helm chart runs DB initialization.
+#
+# Environment Variables:
+#   ESIGNET_NS - eSignet namespace (default: esignet)
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+POSTGRES_NS="postgres"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Mock Identity DB Init Pre-install"
+echo "================================================"
+
+# --- Step 1: Ensure esignet namespace exists with istio ---
+kubectl create namespace "$ESIGNET_NS" --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace "$ESIGNET_NS" istio-injection=enabled --overwrite
+
+# --- Step 2: Copy postgres-postgresql secret to esignet namespace ---
+echo "Copying postgres-postgresql secret to $ESIGNET_NS namespace"
+$COPY_UTIL secret postgres-postgresql "$POSTGRES_NS" "$ESIGNET_NS"
+
+echo "Mock identity DB init pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/mock-identity-system-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/mock-identity-system-preinstall.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Mock Identity System Pre-install
+# =============================================================================
+# Prepares esignet namespace for mock identity system deployment:
+#   - Copies softhsm-mock-identity-system secret from softhsm ns
+#   - Creates mockid-postgres-config with mock identity DB values
+#   - Verifies softhsm-mock-identity-system-share ConfigMap is present
+#
+# Environment Variables:
+#   MOCKID_DB_NAME  - Mock identity DB name (default: mosip_mockidentitysystem)
+#   MOCKID_DB_USER  - Mock identity DB user (default: mockidentityuser)
+#   MOCKID_DB_PORT  - Postgres port (default: 5432)
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+SOFTHSM_NS="softhsm-2-0-0"
+MOCKID_DB_NAME="${MOCKID_DB_NAME:-mosip_mockidentitysystem_2_0_0}"
+MOCKID_DB_USER="${MOCKID_DB_USER:-mockidentityuser_2_0_0}"
+MOCKID_DB_PORT="${MOCKID_DB_PORT:-5432}"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Mock Identity System Pre-install"
+echo "================================================"
+
+kubectl create namespace "$ESIGNET_NS" --dry-run=client -o yaml | kubectl apply -f -
+
+# Copy softhsm-mock-identity-system secret to esignet ns
+# The chart references it directly via secretKeyRef — pod and secret must be in same namespace
+$COPY_UTIL secret softhsm-mock-identity-system-2-0-0 "$SOFTHSM_NS" "$ESIGNET_NS"
+echo "softhsm-mock-identity-system-2-0-0 secret copied to $ESIGNET_NS."
+
+# Read internal host from postgres-config (already present from esignet-preinstall.sh)
+DB_HOST=$(kubectl -n "$ESIGNET_NS" get configmap postgres-config \
+  -o jsonpath='{.data.database-host}' 2>/dev/null || echo "")
+if [ -z "$DB_HOST" ]; then
+  echo "ERROR: postgres-config not found in $ESIGNET_NS — ensure esignet-preinstall.sh has run." >&2
+  exit 1
+fi
+
+# Build mockid-postgres-config — DB name/user/port are fixed for mock identity system
+kubectl -n "$ESIGNET_NS" create configmap mockid-postgres-config \
+  --from-literal=database-host="$DB_HOST" \
+  --from-literal=database-port="$MOCKID_DB_PORT" \
+  --from-literal=database-name="$MOCKID_DB_NAME" \
+  --from-literal=database-username="$MOCKID_DB_USER" \
+  --dry-run=client -o yaml | kubectl apply -f -
+echo "mockid-postgres-config created/updated in $ESIGNET_NS (host=$DB_HOST db=$MOCKID_DB_NAME user=$MOCKID_DB_USER)."
+
+# Verify SoftHSM mock identity configmap exists in esignet namespace
+if kubectl -n "$ESIGNET_NS" get configmap softhsm-mock-identity-system-share &>/dev/null; then
+  echo "SoftHSM mock identity system configmap found."
+else
+  echo "ERROR: softhsm-mock-identity-system-share configmap not found in $ESIGNET_NS namespace."
+  echo "Deploy softhsm-mock-identity-system-2-0-0 before running mock identity system install."
+  exit 1
+fi
+
+echo "Mock identity system pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/mock-relying-party-service-mosipid1-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/mock-relying-party-service-mosipid1-preinstall.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Mock Relying Party Service MOSIPID1 Pre-install
+# =============================================================================
+# Wrapper: sets ESIGNET_NS=esignet-mosipid1 and delegates to base mock-rp-service
+# preinstall (creates private key secrets in the target namespace).
+# =============================================================================
+set -euo pipefail
+export ESIGNET_NS="esignet-mosipid1-2-0-0"
+exec "$WORKDIR/hooks/esignet-standalone-2.0.0/mock-relying-party-service-preinstall.sh"

--- a/Helmsman/hooks/esignet-standalone-2.0.0/mock-relying-party-service-mosipid2-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/mock-relying-party-service-mosipid2-preinstall.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Mock Relying Party Service MOSIPID2 Pre-install
+# =============================================================================
+# Wrapper: sets ESIGNET_NS=esignet-mosipid2 and delegates to base mock-rp-service
+# preinstall (creates private key secrets in the target namespace).
+# =============================================================================
+set -euo pipefail
+export ESIGNET_NS="esignet-mosipid2-2-0-0"
+exec "$WORKDIR/hooks/esignet-standalone-2.0.0/mock-relying-party-service-preinstall.sh"

--- a/Helmsman/hooks/esignet-standalone-2.0.0/mock-relying-party-service-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/mock-relying-party-service-preinstall.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Mock Relying Party Service Pre-install
+# =============================================================================
+# Creates K8s secrets for mock relying party private keys from GitHub Actions
+# environment secrets, then verifies the esignet service is running.
+#
+# Required env vars (set in workflow env: block from GitHub Actions secrets):
+#   MOCK_RELYING_PARTY_CLIENT_PRIVATE_KEY — base64-encoded PEM client private key
+#   MOCK_RELYING_PARTY_JWE_PRIVATE_KEY    — base64-encoded PEM JWE userinfo private key
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+
+CLIENT_KEY_TMPFILE=""
+JWE_KEY_TMPFILE=""
+
+cleanup_temp_files() {
+  [ -n "$CLIENT_KEY_TMPFILE" ] && [ -f "$CLIENT_KEY_TMPFILE" ] && \
+    { shred -u "$CLIENT_KEY_TMPFILE" 2>/dev/null || rm -f "$CLIENT_KEY_TMPFILE"; }
+  [ -n "$JWE_KEY_TMPFILE" ] && [ -f "$JWE_KEY_TMPFILE" ] && \
+    { shred -u "$JWE_KEY_TMPFILE" 2>/dev/null || rm -f "$JWE_KEY_TMPFILE"; }
+}
+trap cleanup_temp_files EXIT INT TERM
+
+echo "================================================"
+echo "eSignet 1.7.1 - Mock Relying Party Service Pre-install"
+echo "================================================"
+
+kubectl create namespace "$ESIGNET_NS" --dry-run=client -o yaml | kubectl apply -f -
+
+# Create mock-relying-party-private-key-jwk (client private key)
+EXISTING=$(kubectl -n "$ESIGNET_NS" get secret mock-relying-party-private-key-jwk \
+  -o jsonpath='{.data.client-private-key}' 2>/dev/null || echo "")
+if [ -z "$EXISTING" ]; then
+  if [ -n "${MOCK_RELYING_PARTY_CLIENT_PRIVATE_KEY:-}" ]; then
+    CLIENT_KEY_TMPFILE=$(mktemp)
+    chmod 600 "$CLIENT_KEY_TMPFILE"
+    echo "$MOCK_RELYING_PARTY_CLIENT_PRIVATE_KEY" | base64 -d | sed "s/'//g" | sed -z 's/\n/\\n/g' > "$CLIENT_KEY_TMPFILE"
+    kubectl -n "$ESIGNET_NS" delete secret mock-relying-party-private-key-jwk --ignore-not-found=true
+    kubectl -n "$ESIGNET_NS" create secret generic mock-relying-party-private-key-jwk \
+      --from-file=client-private-key="$CLIENT_KEY_TMPFILE"
+    echo "mock-relying-party-private-key-jwk created."
+  else
+    echo "ERROR: MOCK_RELYING_PARTY_CLIENT_PRIVATE_KEY is not set." >&2
+    exit 1
+  fi
+else
+  echo "mock-relying-party-private-key-jwk already exists, skipping."
+fi
+
+# Create jwe-userinfo-service-secrets (JWE userinfo private key)
+EXISTING=$(kubectl -n "$ESIGNET_NS" get secret jwe-userinfo-service-secrets \
+  -o jsonpath='{.data.jwe-userinfo-private-key}' 2>/dev/null || echo "")
+if [ -z "$EXISTING" ]; then
+  if [ -n "${MOCK_RELYING_PARTY_JWE_PRIVATE_KEY:-}" ]; then
+    JWE_KEY_TMPFILE=$(mktemp)
+    chmod 600 "$JWE_KEY_TMPFILE"
+    echo "$MOCK_RELYING_PARTY_JWE_PRIVATE_KEY" | base64 -d | sed "s/'//g" | sed -z 's/\n/\\n/g' > "$JWE_KEY_TMPFILE"
+    kubectl -n "$ESIGNET_NS" delete secret jwe-userinfo-service-secrets --ignore-not-found=true
+    kubectl -n "$ESIGNET_NS" create secret generic jwe-userinfo-service-secrets \
+      --from-file=jwe-userinfo-private-key="$JWE_KEY_TMPFILE"
+    echo "jwe-userinfo-service-secrets created."
+  else
+    echo "ERROR: MOCK_RELYING_PARTY_JWE_PRIVATE_KEY is not set." >&2
+    exit 1
+  fi
+else
+  echo "jwe-userinfo-service-secrets already exists, skipping."
+fi
+
+echo "Mock relying party service pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/mock-relying-party-service-sunbird-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/mock-relying-party-service-sunbird-preinstall.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Mock Relying Party Service Sunbird Pre-install
+# =============================================================================
+# Wrapper: sets ESIGNET_NS=esignet-sunbird and delegates to base mock-rp-service
+# preinstall (creates private key secrets in the target namespace).
+# =============================================================================
+set -euo pipefail
+export ESIGNET_NS="esignet-sunbird-2-0-0"
+exec "$WORKDIR/hooks/esignet-standalone-2.0.0/mock-relying-party-service-preinstall.sh"

--- a/Helmsman/hooks/esignet-standalone-2.0.0/mock-relying-party-ui-mosipid1-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/mock-relying-party-ui-mosipid1-preinstall.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Mock Relying Party UI MOSIPID1 Pre-install
+# =============================================================================
+# Ensures esignet-mosipid1 namespace exists and verifies mock-relying-party-service
+# is available in the esignet-mosipid1 namespace before UI deployment.
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="esignet-mosipid1-2-0-0"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Mock Relying Party UI MOSIPID1 Pre-install"
+echo "================================================"
+
+kubectl create namespace "$ESIGNET_NS" --dry-run=client -o yaml | kubectl apply -f -
+
+if kubectl -n "$ESIGNET_NS" get svc mock-relying-party-service-2-0-0 &>/dev/null; then
+  echo "Mock relying party service found in $ESIGNET_NS."
+else
+  echo "WARNING: Mock relying party service not found in $ESIGNET_NS. UI depends on the service being deployed."
+fi
+
+echo "Mock relying party UI MOSIPID1 pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/mock-relying-party-ui-mosipid2-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/mock-relying-party-ui-mosipid2-preinstall.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Mock Relying Party UI MOSIPID2 Pre-install
+# =============================================================================
+# Ensures esignet-mosipid2 namespace exists and verifies mock-relying-party-service
+# is available in the esignet-mosipid2 namespace before UI deployment.
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="esignet-mosipid2-2-0-0"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Mock Relying Party UI MOSIPID2 Pre-install"
+echo "================================================"
+
+kubectl create namespace "$ESIGNET_NS" --dry-run=client -o yaml | kubectl apply -f -
+
+if kubectl -n "$ESIGNET_NS" get svc mock-relying-party-service-2-0-0 &>/dev/null; then
+  echo "Mock relying party service found in $ESIGNET_NS."
+else
+  echo "WARNING: Mock relying party service not found in $ESIGNET_NS. UI depends on the service being deployed."
+fi
+
+echo "Mock relying party UI MOSIPID2 pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/mock-relying-party-ui-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/mock-relying-party-ui-preinstall.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Mock Relying Party UI Pre-install
+# =============================================================================
+# Prepares for mock relying party UI deployment.
+# =============================================================================
+set -euo pipefail
+
+echo "================================================"
+echo "eSignet 1.7.1 - Mock Relying Party UI Pre-install"
+echo "================================================"
+
+# Ensure esignet namespace exists
+kubectl create namespace esignet-mock-2-0-0 --dry-run=client -o yaml | kubectl apply -f -
+
+# Verify mock relying party service is available
+if kubectl -n esignet-mock-2-0-0 get svc mock-relying-party-service-2-0-0 &>/dev/null; then
+  echo "Mock relying party service found."
+else
+  echo "WARNING: Mock relying party service not found. UI depends on the service being deployed."
+fi
+
+echo "Mock relying party UI pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/mock-relying-party-ui-sunbird-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/mock-relying-party-ui-sunbird-preinstall.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Mock Relying Party UI Sunbird Pre-install
+# =============================================================================
+# Ensures esignet-sunbird namespace exists and verifies mock-relying-party-service
+# is available in the esignet-sunbird namespace before UI deployment.
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="esignet-sunbird-2-0-0"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Mock Relying Party UI Sunbird Pre-install"
+echo "================================================"
+
+kubectl create namespace "$ESIGNET_NS" --dry-run=client -o yaml | kubectl apply -f -
+
+if kubectl -n "$ESIGNET_NS" get svc mock-relying-party-service-2-0-0 &>/dev/null; then
+  echo "Mock relying party service found in $ESIGNET_NS."
+else
+  echo "WARNING: Mock relying party service not found in $ESIGNET_NS. UI depends on the service being deployed."
+fi
+
+echo "Mock relying party UI Sunbird pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/notifier-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/notifier-postinstall.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Notifier Post-install
+# =============================================================================
+# Based on: esignet-signup/deploy/kernel/install.sh
+# Patches notifier deployment with SMS number length env vars after install.
+# =============================================================================
+set -euo pipefail
+
+KERNEL_NS="kernel-2-0-0"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Notifier Post-install"
+echo "================================================"
+
+# Source: deploy/kernel/install.sh - kubectl set env deployment/notifier
+echo "Setting SMS number length env vars on notifier-2-0-0 deployment"
+kubectl -n "$KERNEL_NS" set env deployment/notifier-2-0-0 \
+  MOSIP_KERNEL_SMS_NUMBER_MIN_LENGTH=7 \
+  MOSIP_KERNEL_SMS_NUMBER_MAX_LENGTH=10
+
+echo "Notifier post-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/oidc-ui-mosipid1-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/oidc-ui-mosipid1-preinstall.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - OIDC UI MOSIPID1 Pre-install
+# =============================================================================
+# Wrapper: sets ESIGNET_NS=esignet-mosipid1 and delegates to base oidc-ui preinstall.
+# =============================================================================
+set -euo pipefail
+export ESIGNET_NS="esignet-mosipid1-2-0-0"
+exec "$WORKDIR/hooks/esignet-standalone-2.0.0/oidc-ui-preinstall.sh"

--- a/Helmsman/hooks/esignet-standalone-2.0.0/oidc-ui-mosipid2-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/oidc-ui-mosipid2-preinstall.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - OIDC UI MOSIPID2 Pre-install
+# =============================================================================
+# Wrapper: sets ESIGNET_NS=esignet-mosipid2 and delegates to base oidc-ui preinstall.
+# =============================================================================
+set -euo pipefail
+export ESIGNET_NS="esignet-mosipid2-2-0-0"
+exec "$WORKDIR/hooks/esignet-standalone-2.0.0/oidc-ui-preinstall.sh"

--- a/Helmsman/hooks/esignet-standalone-2.0.0/oidc-ui-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/oidc-ui-preinstall.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - OIDC UI Pre-install
+# =============================================================================
+# Based on: deploy/oidc-ui/install.sh
+# Waits for eSignet service readiness before deploying OIDC UI.
+# Theme, language, and provider name are configured via DSF helm set values.
+#
+# Environment Variables:
+#   ESIGNET_NS   - eSignet namespace (default: esignet)
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+
+echo "================================================"
+echo "eSignet 1.7.1 - OIDC UI Pre-install"
+echo "================================================"
+
+# --- Step 1: Ensure esignet namespace exists ---
+kubectl create namespace "$ESIGNET_NS" --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace "$ESIGNET_NS" istio-injection=enabled --overwrite
+
+# --- Step 2: Update helm repos ---
+helm repo add mosip https://mosip.github.io/mosip-helm || true
+helm repo update
+
+# --- Step 3: Wait for eSignet service to be available ---
+# Source: deploy/oidc-ui/install.sh - eSignet must be running before OIDC UI
+echo "Waiting for eSignet service to be ready..."
+kubectl -n "$ESIGNET_NS" wait --for=condition=ready pod -l app.kubernetes.io/name=esignet --timeout=480s || \
+  { echo "ERROR: eSignet pods not ready after timeout" >&2; exit 1; }
+
+echo "OIDC UI pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/oidc-ui-sunbird-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/oidc-ui-sunbird-preinstall.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - OIDC UI Sunbird Pre-install
+# =============================================================================
+# Wrapper: sets ESIGNET_NS=esignet-sunbird and delegates to base oidc-ui preinstall.
+# =============================================================================
+set -euo pipefail
+export ESIGNET_NS="esignet-sunbird-2-0-0"
+exec "$WORKDIR/hooks/esignet-standalone-2.0.0/oidc-ui-preinstall.sh"

--- a/Helmsman/hooks/esignet-standalone-2.0.0/pms-partner-mosipid1-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/pms-partner-mosipid1-preinstall.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - PMS Partner MOSIPID1 Pre-install
+# =============================================================================
+# Creates the Istio Gateway for pms-partner in esignet-mosipid1 namespace.
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="esignet-mosipid1-2-0-0"
+
+echo "================================================"
+echo "eSignet 1.7.1 - PMS Partner MOSIPID1 Pre-install"
+echo "================================================"
+
+kubectl apply -f - <<EOF
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: pms-partner-mosipid1-gateway
+  namespace: ${ESIGNET_NS}
+  labels:
+    app.kubernetes.io/instance: pms-partner-mosipid1-2-0-0
+    app.kubernetes.io/name: pms-partner
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - hosts:
+        - pms-mosipid1-2-0-0.${domain_name}
+      port:
+        name: https
+        number: 443
+        protocol: HTTPS
+      tls:
+        credentialName: pms-partner-mosipid1-tls
+        mode: SIMPLE
+    - hosts:
+        - pms-mosipid1-2-0-0.${domain_name}
+      port:
+        name: http
+        number: 80
+        protocol: HTTP
+EOF
+
+echo "pms-partner-mosipid1-gateway created/updated in $ESIGNET_NS."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/pms-partner-mosipid2-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/pms-partner-mosipid2-preinstall.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - PMS Partner MOSIPID2 Pre-install
+# =============================================================================
+# Creates the Istio Gateway for pms-partner in esignet-mosipid2 namespace.
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="esignet-mosipid2-2-0-0"
+
+echo "================================================"
+echo "eSignet 1.7.1 - PMS Partner MOSIPID2 Pre-install"
+echo "================================================"
+
+kubectl apply -f - <<EOF
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: pms-partner-mosipid2-gateway
+  namespace: ${ESIGNET_NS}
+  labels:
+    app.kubernetes.io/instance: pms-partner-mosipid2-2-0-0
+    app.kubernetes.io/name: pms-partner
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - hosts:
+        - pms-mosipid2-2-0-0.${domain_name}
+      port:
+        name: https
+        number: 443
+        protocol: HTTPS
+      tls:
+        credentialName: pms-partner-mosipid2-tls
+        mode: SIMPLE
+    - hosts:
+        - pms-mosipid2-2-0-0.${domain_name}
+      port:
+        name: http
+        number: 80
+        protocol: HTTP
+EOF
+
+echo "pms-partner-mosipid2-gateway created/updated in $ESIGNET_NS."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/postgres-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/postgres-postinstall.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Postgres Post-install
+# =============================================================================
+# Based on: deploy/postgres/generate-secret-cm.py
+# Creates postgres secrets (db-common-secrets) and configmap (postgres-config)
+# after PostgreSQL helm chart deployment. Replaces interactive Python script
+# with environment variable driven approach.
+#
+# Environment Variables:
+#   DB_USER_PASSWORD     - Database user password (REQUIRED)
+#   POSTGRES_HOST        - PostgreSQL host (default: postgres-postgresql.postgres)
+#   POSTGRES_PORT        - PostgreSQL port (default: 5432)
+#   DB_USER              - Database username (default: esignetuser)
+#   DB_NAME              - Database name (default: mosip_esignet)
+# =============================================================================
+set -euo pipefail
+
+POSTGRES_NS="postgres"
+POSTGRES_HOST="${POSTGRES_HOST:-postgres-postgresql.postgres}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+DB_USER="${DB_USER:-esignetuser}"
+DB_NAME="${DB_NAME:-mosip_esignet}"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Postgres Post-install"
+echo "================================================"
+
+
+# --- Step 1: Create postgres-config configmap ---
+# Source: deploy/postgres/generate-secret-cm.py -> create_or_update_configmap()
+echo "Creating postgres-config configmap in $POSTGRES_NS namespace"
+kubectl -n "$POSTGRES_NS" create configmap postgres-config \
+  --from-literal=database-host="$POSTGRES_HOST" \
+  --from-literal=database-port="$POSTGRES_PORT" \
+  --from-literal=database-username="$DB_USER" \
+  --from-literal=database-name="$DB_NAME" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Postgres post-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/postgres-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/postgres-preinstall.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Postgres Pre-install
+# =============================================================================
+# Based on: deploy/install-prereq.sh
+# Creates esignet namespace, applies esignet-global configmap, and prepares
+# postgres namespace before PostgreSQL helm chart deployment.
+#
+# Environment Variables:
+#   INSTALLATION_DOMAIN  - Base domain (default: sandbox.xyz.net)
+#   ESIGNET_NS           - eSignet namespace (default: esignet)
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+INSTALLATION_DOMAIN="${INSTALLATION_DOMAIN:-sandbox.xyz.net}"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Postgres Pre-install"
+echo "================================================"
+
+# --- Step 1: Create esignet namespace (referenced by esignet-global configmap) ---
+echo "Creating $ESIGNET_NS namespace"
+kubectl create namespace "$ESIGNET_NS" --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace "$ESIGNET_NS" istio-injection=enabled --overwrite
+
+# --- Step 2: Prepare postgres namespace ---
+echo "Creating postgres namespace"
+kubectl create namespace postgres --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace postgres istio-injection=enabled --overwrite
+
+echo "Postgres pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/redis-setup.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/redis-setup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Redis Post-install Setup
+# =============================================================================
+# Based on: deploy/redis/install.sh + deploy/install-prereq.sh (redis section)
+# Creates redis-config configmap and shares Redis credentials with the
+# esignet namespace after Redis deployment.
+#
+# Environment Variables:
+#   ESIGNET_NS   - eSignet namespace (default: esignet)
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+REDIS_NS="redis"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Redis Post-install Setup"
+echo "================================================"
+
+# --- Step 1: Wait for Redis to be ready ---
+echo "Waiting for Redis pods to be ready..."
+kubectl -n "$REDIS_NS" wait --for=condition=ready pod -l app.kubernetes.io/name=redis --timeout=480s || \
+  { echo "ERROR: Redis pods not ready after timeout" >&2; exit 1; }
+
+# --- Step 2: Apply redis-config configmap in redis namespace ---
+echo "Creating redis-config configmap in $REDIS_NS namespace"
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+  namespace: ${REDIS_NS}
+  labels:
+    app: redis
+data:
+  redis-host: "redis-master-0.redis-headless.redis.svc.cluster.local"
+  redis-port: "6379"
+EOF
+
+# --- Step 3: Copy redis-config configmap to esignet namespace ---
+echo "Copying redis-config configmap to $ESIGNET_NS namespace"
+$COPY_UTIL configmap redis-config "$REDIS_NS" "$ESIGNET_NS"
+
+# --- Step 4: Copy redis secret to esignet namespace ---
+echo "Copying redis secret to $ESIGNET_NS namespace"
+$COPY_UTIL secret redis "$REDIS_NS" "$ESIGNET_NS"
+
+echo "Redis setup completed. Config and credentials shared with $ESIGNET_NS namespace."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/signup-init-db.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/signup-init-db.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Signup Service DB Init Pre-install
+# =============================================================================
+# Based on: esignet-signup/deploy/postgres-init.sh
+# Creates signup namespace and copies postgres secrets before
+# the postgres-init helm chart runs DB initialization for
+# mosip_audit, mosip_kernel, and mosip_otp.
+#
+# Environment Variables:
+#   SIGNUP_NS - Signup namespace (default: signup)
+# =============================================================================
+set -euo pipefail
+
+SIGNUP_NS="${SIGNUP_NS:-signup-2-0-0}"
+POSTGRES_NS="postgres"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Signup DB Init Pre-install"
+echo "================================================"
+
+# --- Step 1: Ensure signup namespace exists with istio ---
+kubectl create namespace "$SIGNUP_NS" --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace "$SIGNUP_NS" istio-injection=enabled --overwrite
+
+# --- Step 2: Copy postgres-postgresql secret to signup namespace ---
+echo "Copying postgres-postgresql secret to $SIGNUP_NS namespace"
+$COPY_UTIL secret postgres-postgresql "$POSTGRES_NS" "$SIGNUP_NS"
+
+echo "Signup DB init pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/signup-keycloak-init-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/signup-keycloak-init-postinstall.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 
 SIGNUP_NS="${SIGNUP_NS:-signup-2-0-0}"
 KEYCLOAK_NS="keycloak"
-SECRET_KEY="mosip_signup-2-0-0_client_secret"
+SECRET_KEY="mosip_signup_client_secret"
 
 echo "================================================"
 echo "eSignet 1.7.1 - Signup Keycloak Init Post-install"

--- a/Helmsman/hooks/esignet-standalone-2.0.0/signup-keycloak-init-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/signup-keycloak-init-postinstall.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Signup Keycloak Init Post-install
+# =============================================================================
+# Based on: esignet-signup/deploy/keycloak/keycloak-init.sh
+# Syncs mosip_signup_client_secret from signup namespace back to
+# keycloak namespace so it can be shared with other services.
+#
+# Environment Variables:
+#   SIGNUP_NS - Signup namespace (default: signup)
+# =============================================================================
+set -euo pipefail
+
+SIGNUP_NS="${SIGNUP_NS:-signup-2-0-0}"
+KEYCLOAK_NS="keycloak"
+SECRET_KEY="mosip_signup-2-0-0_client_secret"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Signup Keycloak Init Post-install"
+echo "================================================"
+
+# Sync mosip_signup_client_secret from signup ns back to keycloak ns
+if kubectl -n "$SIGNUP_NS" get secret keycloak-client-secrets &>/dev/null; then
+  SECRET_B64=$(kubectl -n "$SIGNUP_NS" get secret keycloak-client-secrets \
+    -o jsonpath="{.data.$SECRET_KEY}" 2>/dev/null || echo "")
+  if [[ -n "$SECRET_B64" ]]; then
+    echo "Syncing $SECRET_KEY back to $KEYCLOAK_NS namespace"
+    if kubectl -n "$KEYCLOAK_NS" get secret keycloak-client-secrets &>/dev/null; then
+      kubectl -n "$KEYCLOAK_NS" patch secret keycloak-client-secrets \
+        --type=merge \
+        -p "{\"data\":{\"$SECRET_KEY\":\"$SECRET_B64\"}}" || true
+    else
+      kubectl -n "$KEYCLOAK_NS" create secret generic keycloak-client-secrets \
+        --from-literal=dummy=placeholder \
+        --dry-run=client -o yaml | kubectl apply -f -
+      kubectl -n "$KEYCLOAK_NS" patch secret keycloak-client-secrets \
+        --type=merge \
+        -p "{\"data\":{\"$SECRET_KEY\":\"$SECRET_B64\"}}" || true
+    fi
+    echo "$SECRET_KEY synced to $KEYCLOAK_NS namespace."
+  fi
+fi
+
+echo "Signup keycloak init post-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/signup-keycloak-init-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/signup-keycloak-init-preinstall.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Signup Keycloak Init Pre-install
+# =============================================================================
+# Based on: esignet-signup/deploy/keycloak/keycloak-init.sh
+# Copies keycloak configmaps/secrets to signup namespace and ensures
+# keycloak-client-secrets contains mosip_signup_client_secret before
+# the keycloak-init helm chart runs.
+#
+# On first deploy: generates a UUID secret if none exists in keycloak ns.
+# On re-deploy:    propagates the existing secret from keycloak namespace.
+#
+# Environment Variables:
+#   SIGNUP_NS - Signup namespace (default: signup)
+# =============================================================================
+set -euo pipefail
+
+SIGNUP_NS="${SIGNUP_NS:-signup-2-0-0}"
+KEYCLOAK_NS="keycloak"
+SECRET_KEY="mosip_signup-2-0-0_client_secret"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Signup Keycloak Init Pre-install"
+echo "================================================"
+
+# --- Step 1: Ensure signup namespace exists with istio ---
+kubectl create namespace "$SIGNUP_NS" --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace "$SIGNUP_NS" istio-injection=enabled --overwrite
+
+# --- Step 2: Copy keycloak-env-vars configmap ---
+echo "Copying keycloak-env-vars to $SIGNUP_NS namespace"
+$COPY_UTIL configmap keycloak-env-vars "$KEYCLOAK_NS" "$SIGNUP_NS"
+
+# --- Step 3: Copy keycloak secret ---
+echo "Copying keycloak secret to $SIGNUP_NS namespace"
+$COPY_UTIL secret keycloak "$KEYCLOAK_NS" "$SIGNUP_NS"
+
+# --- Step 4: Ensure keycloak-client-secrets has mosip_signup_client_secret ---
+echo "Ensuring mosip_signup-2-0-0_client_secret exists in $SIGNUP_NS"
+if kubectl -n "$KEYCLOAK_NS" get secret keycloak-client-secrets &>/dev/null && \
+   kubectl -n "$KEYCLOAK_NS" get secret keycloak-client-secrets \
+     -o jsonpath="{.data.$SECRET_KEY}" 2>/dev/null | grep -q '.'; then
+  echo "Found existing $SECRET_KEY in keycloak namespace — propagating to $SIGNUP_NS"
+  SECRET_B64=$(kubectl -n "$KEYCLOAK_NS" get secret keycloak-client-secrets \
+    -o jsonpath="{.data.$SECRET_KEY}")
+else
+  echo "No existing $SECRET_KEY found — generating new secret"
+  SECRET_B64=$(python3 -c "import uuid, base64; print(base64.b64encode(str(uuid.uuid4()).encode()).decode())")
+fi
+
+kubectl -n "$SIGNUP_NS" create secret generic keycloak-client-secrets \
+  --from-literal=dummy=placeholder \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n "$SIGNUP_NS" patch secret keycloak-client-secrets \
+  --type=merge \
+  -p "{\"data\":{\"$SECRET_KEY\":\"$SECRET_B64\"}}"
+
+echo "Signup keycloak init pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/signup-keycloak-init-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/signup-keycloak-init-preinstall.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 
 SIGNUP_NS="${SIGNUP_NS:-signup-2-0-0}"
 KEYCLOAK_NS="keycloak"
-SECRET_KEY="mosip_signup-2-0-0_client_secret"
+SECRET_KEY="mosip_signup_client_secret"
 COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
 
 echo "================================================"
@@ -37,7 +37,7 @@ echo "Copying keycloak secret to $SIGNUP_NS namespace"
 $COPY_UTIL secret keycloak "$KEYCLOAK_NS" "$SIGNUP_NS"
 
 # --- Step 4: Ensure keycloak-client-secrets has mosip_signup_client_secret ---
-echo "Ensuring mosip_signup-2-0-0_client_secret exists in $SIGNUP_NS"
+echo "Ensuring mosip_signup_client_secret exists in $SIGNUP_NS"
 if kubectl -n "$KEYCLOAK_NS" get secret keycloak-client-secrets &>/dev/null && \
    kubectl -n "$KEYCLOAK_NS" get secret keycloak-client-secrets \
      -o jsonpath="{.data.$SECRET_KEY}" 2>/dev/null | grep -q '.'; then

--- a/Helmsman/hooks/esignet-standalone-2.0.0/signup-service-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/signup-service-preinstall.sh
@@ -6,7 +6,7 @@
 # Sets up all prerequisites for signup-service:
 #   - Copies redis-config configmap and redis secret
 #   - Creates keycloak-host configmap (KEYCLOAK_EXTERNAL_URL)
-#   - Creates empty signup-captcha secret (update site/secret keys for prod)
+#   - Creates empty signup-captcha-2-0-0 secret (update site/secret keys for prod)
 #   - Creates empty signup-keystore and signup-keystore-password secrets
 #   - Creates msg-gateway configmap and secret (default: mock-smtp)
 #
@@ -47,24 +47,24 @@ kubectl -n "$SIGNUP_NS" create configmap keycloak-host \
   --from-literal=keycloak-internal-url="http://keycloak.$KEYCLOAK_NS" \
   --dry-run=client -o yaml | kubectl apply -f -
 
-# --- Step 4: Create signup-captcha secret ---
-echo "Creating signup-captcha secret in $SIGNUP_NS"
-kubectl -n "$SIGNUP_NS" create secret generic signup-captcha \
-  --from-literal=signup-captcha-site-key="$CAPTCHA_SITE_KEY" \
-  --from-literal=signup-captcha-secret-key="$CAPTCHA_SECRET_KEY" \
+# --- Step 4: Create signup-captcha-2-0-0 secret ---
+echo "Creating signup-captcha-2-0-0 secret in $SIGNUP_NS"
+kubectl -n "$SIGNUP_NS" create secret generic signup-captcha-2-0-0 \
+  --from-literal=signup-captcha-2-0-0-site-key="$CAPTCHA_SITE_KEY" \
+  --from-literal=signup-captcha-2-0-0-secret-key="$CAPTCHA_SECRET_KEY" \
   --dry-run=client -o yaml | kubectl apply -f -
 
-echo "Copying signup-captcha secret to captcha namespace"
-$COPY_UTIL secret signup-captcha "$SIGNUP_NS" "captcha"
+echo "Copying signup-captcha-2-0-0 secret to captcha namespace"
+$COPY_UTIL secret signup-captcha-2-0-0 "$SIGNUP_NS" "captcha"
 
 echo "Patching captcha deployment with signup-2-0-0 secret key"
 ENV_VAR_EXISTS=$(kubectl -n captcha get deployment captcha \
-  -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_SIGNUP')].name}" 2>/dev/null || echo "")
+  -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_SIGNUP_2_0_0')].name}" 2>/dev/null || echo "")
 if [[ -z "$ENV_VAR_EXISTS" ]]; then
   kubectl patch deployment -n captcha captcha --type='json' \
-    -p='[{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_SIGNUP", "valueFrom": {"secretKeyRef": {"name": "signup-captcha", "key": "signup-captcha-secret-key"}}}}]'
+    -p='[{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_SIGNUP_2_0_0", "valueFrom": {"secretKeyRef": {"name": "signup-captcha-2-0-0", "key": "signup-captcha-2-0-0-secret-key"}}}}]'
 else
-  echo "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_SIGNUP already exists."
+  echo "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_SIGNUP_2_0_0 already exists."
 fi
 
 # --- Step 5: Create signup-keystore secrets ---

--- a/Helmsman/hooks/esignet-standalone-2.0.0/signup-service-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/signup-service-preinstall.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Signup Service Pre-install
+# =============================================================================
+# Based on: esignet-signup/deploy/prereq.sh + deploy/msg-gateway/install.sh
+# Sets up all prerequisites for signup-service:
+#   - Copies redis-config configmap and redis secret
+#   - Creates keycloak-host configmap (KEYCLOAK_EXTERNAL_URL)
+#   - Creates empty signup-captcha secret (update site/secret keys for prod)
+#   - Creates empty signup-keystore and signup-keystore-password secrets
+#   - Creates msg-gateway configmap and secret (default: mock-smtp)
+#
+# Environment Variables:
+#   SIGNUP_NS              - Signup namespace (default: signup)
+#   MOSIP_IAM_EXTERNAL_HOST - Keycloak external host (e.g. iam.sandbox.xyz.net)
+#   MOSIP_SIGNUP_CAPTCHA_SITE_KEY   - reCAPTCHA site key (default: empty)
+#   MOSIP_SIGNUP_CAPTCHA_SECRET_KEY - reCAPTCHA secret key (default: empty)
+# =============================================================================
+set -euo pipefail
+
+SIGNUP_NS="${SIGNUP_NS:-signup-2-0-0}"
+REDIS_NS="redis"
+KEYCLOAK_NS="keycloak"
+IAM_EXTERNAL_HOST="${MOSIP_IAM_EXTERNAL_HOST:-}"
+CAPTCHA_SITE_KEY="${MOSIP_SIGNUP_CAPTCHA_SITE_KEY:-}"
+CAPTCHA_SECRET_KEY="${MOSIP_SIGNUP_CAPTCHA_SECRET_KEY:-}"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Signup Service Pre-install"
+echo "================================================"
+
+# --- Step 1: Ensure signup namespace exists with istio ---
+kubectl create namespace "$SIGNUP_NS" --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace "$SIGNUP_NS" istio-injection=enabled --overwrite
+
+# --- Step 2: Copy redis configmap and secret ---
+echo "Copying redis-config to $SIGNUP_NS namespace"
+$COPY_UTIL configmap redis-config "$REDIS_NS" "$SIGNUP_NS"
+echo "Copying redis secret to $SIGNUP_NS namespace"
+$COPY_UTIL secret redis "$REDIS_NS" "$SIGNUP_NS"
+
+# --- Step 3: Create keycloak-host configmap ---
+echo "Creating keycloak-host configmap in $SIGNUP_NS"
+kubectl -n "$SIGNUP_NS" create configmap keycloak-host \
+  --from-literal=keycloak-external-url="https://$IAM_EXTERNAL_HOST/auth" \
+  --from-literal=keycloak-internal-url="http://keycloak.$KEYCLOAK_NS" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# --- Step 4: Create signup-captcha secret ---
+echo "Creating signup-captcha secret in $SIGNUP_NS"
+kubectl -n "$SIGNUP_NS" create secret generic signup-captcha \
+  --from-literal=signup-captcha-site-key="$CAPTCHA_SITE_KEY" \
+  --from-literal=signup-captcha-secret-key="$CAPTCHA_SECRET_KEY" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Copying signup-captcha secret to captcha namespace"
+$COPY_UTIL secret signup-captcha "$SIGNUP_NS" "captcha"
+
+echo "Patching captcha deployment with signup-2-0-0 secret key"
+ENV_VAR_EXISTS=$(kubectl -n captcha get deployment captcha \
+  -o jsonpath="{.spec.template.spec.containers[0].env[?(@.name=='MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_SIGNUP')].name}" 2>/dev/null || echo "")
+if [[ -z "$ENV_VAR_EXISTS" ]]; then
+  kubectl patch deployment -n captcha captcha --type='json' \
+    -p='[{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_SIGNUP", "valueFrom": {"secretKeyRef": {"name": "signup-captcha", "key": "signup-captcha-secret-key"}}}}]'
+else
+  echo "MOSIP_CAPTCHA_GOOGLERECAPTCHAV2_SECRET_SIGNUP already exists."
+fi
+
+# --- Step 5: Create signup-keystore secrets ---
+echo "Creating signup-keystore secrets in $SIGNUP_NS"
+kubectl -n "$SIGNUP_NS" create secret generic signup-keystore-password \
+  --from-literal=signup-keystore-password='' \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n "$SIGNUP_NS" create secret generic signup-keystore \
+  --from-literal=oidckeystore.p12='' \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# --- Step 6: Create msg-gateway configmap and secret (pointing to mock-smtp) ---
+echo "Creating msg-gateway configmap and secret in $SIGNUP_NS"
+kubectl -n "$SIGNUP_NS" create configmap msg-gateway \
+  --from-literal=smtp-host="mock-smtp-2-0-0.mock-smtp-2-0-0" \
+  --from-literal=sms-host="mock-smtp-2-0-0.mock-smtp-2-0-0" \
+  --from-literal=smtp-port="8025" \
+  --from-literal=sms-port="8080" \
+  --from-literal=smtp-username="" \
+  --from-literal=sms-username="" \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n "$SIGNUP_NS" create secret generic msg-gateway \
+  --from-literal=smtp-secret='' \
+  --from-literal=sms-secret='' \
+  --from-literal=sms-authkey='authkey' \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Signup service pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/softhsm-esignet-mosipid1-setup.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/softhsm-esignet-mosipid1-setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - SoftHSM eSignet MOSIPID1 Pre-install Setup
+# =============================================================================
+# Wrapper: sets ESIGNET_NS=esignet-mosipid1 and delegates to base softhsm setup.
+# =============================================================================
+set -euo pipefail
+export ESIGNET_NS="esignet-mosipid1-2-0-0"
+exec "$WORKDIR/hooks/esignet-standalone-2.0.0/softhsm-esignet-setup.sh"

--- a/Helmsman/hooks/esignet-standalone-2.0.0/softhsm-esignet-mosipid2-setup.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/softhsm-esignet-mosipid2-setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - SoftHSM eSignet MOSIPID2 Pre-install Setup
+# =============================================================================
+# Wrapper: sets ESIGNET_NS=esignet-mosipid2 and delegates to base softhsm setup.
+# =============================================================================
+set -euo pipefail
+export ESIGNET_NS="esignet-mosipid2-2-0-0"
+exec "$WORKDIR/hooks/esignet-standalone-2.0.0/softhsm-esignet-setup.sh"

--- a/Helmsman/hooks/esignet-standalone-2.0.0/softhsm-esignet-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/softhsm-esignet-postinstall.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - SoftHSM eSignet Post-install
+# =============================================================================
+# Based on: deploy/esignet/install.sh (copy_cm_func.sh calls for softhsm)
+# Shares SoftHSM configmap and secrets from softhsm namespace to esignet
+# namespace after SoftHSM deployment.
+#
+# Environment Variables:
+#   SOFTHSM_NS   - SoftHSM namespace (default: softhsm)
+#   ESIGNET_NS   - eSignet namespace (default: esignet)
+# =============================================================================
+set -euo pipefail
+
+SOFTHSM_NS="${SOFTHSM_NS:-softhsm-2-0-0}"
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - SoftHSM eSignet Post-install"
+echo "================================================"
+
+# --- Step 1: Wait for SoftHSM pod to be ready ---
+echo "Waiting for SoftHSM pod to be ready..."
+kubectl -n "$SOFTHSM_NS" wait --for=condition=ready pod -l app.kubernetes.io/instance=esignet-softhsm-2-0-0 --timeout=480s || \
+  { echo "ERROR: SoftHSM pod not ready after timeout" >&2; exit 1; }
+
+# --- Step 2: Copy esignet-softhsm-share configmap to esignet namespace ---
+echo "Copying esignet-softhsm-share configmap to $ESIGNET_NS namespace"
+$COPY_UTIL configmap esignet-softhsm-share "$SOFTHSM_NS" "$ESIGNET_NS" 2>/dev/null || \
+  echo "WARNING: esignet-softhsm-share configmap not found in $SOFTHSM_NS"
+
+# --- Step 3: Copy esignet-softhsm secret to esignet namespace ---
+echo "Copying esignet-softhsm-2-0-0 secret to $ESIGNET_NS namespace"
+$COPY_UTIL secret esignet-softhsm-2-0-0 "$SOFTHSM_NS" "$ESIGNET_NS" 2>/dev/null || \
+  echo "WARNING: esignet-softhsm-2-0-0 secret not found in $SOFTHSM_NS"
+
+echo "SoftHSM eSignet post-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/softhsm-esignet-setup.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/softhsm-esignet-setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - SoftHSM eSignet Pre-install Setup
+# =============================================================================
+# Based on: deploy/softhsm/install.sh
+# softhsm-esignet deploys in the esignet namespace (v1.7.1 pattern) so
+# esignet-softhsm-share configmap is created there directly — no cross-ns copy.
+#
+# Environment Variables:
+#   ESIGNET_NS   - eSignet namespace (default: esignet)
+# =============================================================================
+set -euo pipefail
+
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+
+echo "================================================"
+echo "eSignet 1.7.1 - SoftHSM eSignet Pre-install"
+echo "================================================"
+
+# Ensure esignet namespace exists with Istio injection enabled
+echo "Ensuring $ESIGNET_NS namespace exists"
+kubectl create namespace "$ESIGNET_NS" --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace "$ESIGNET_NS" istio-injection=enabled --overwrite
+
+# Update helm repos
+echo "Updating helm repos"
+helm repo update
+
+echo "SoftHSM eSignet pre-install setup completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/softhsm-esignet-sunbird-setup.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/softhsm-esignet-sunbird-setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - SoftHSM eSignet Sunbird Pre-install Setup
+# =============================================================================
+# Wrapper: sets ESIGNET_NS=esignet-sunbird and delegates to base softhsm setup.
+# =============================================================================
+set -euo pipefail
+export ESIGNET_NS="esignet-sunbird-2-0-0"
+exec "$WORKDIR/hooks/esignet-standalone-2.0.0/softhsm-esignet-setup.sh"

--- a/Helmsman/hooks/esignet-standalone-2.0.0/softhsm-mock-identity-system-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/softhsm-mock-identity-system-postinstall.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - SoftHSM Mock Identity System Post-install
+# =============================================================================
+# Copies chart-generated softhsm-mock-identity-system-share configmap
+# (PKCS11 slot/token config) from softhsm namespace to esignet-mock namespace.
+# The security PIN is handled separately via secret copy in preinstall.
+# =============================================================================
+set -euo pipefail
+
+SOFTHSM_NS="${SOFTHSM_NS:-softhsm-2-0-0}"
+ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - SoftHSM Mock Identity System Post-install"
+echo "================================================"
+
+# Wait for SoftHSM mock identity pod to be ready
+kubectl -n "$SOFTHSM_NS" wait --for=condition=ready pod -l app.kubernetes.io/instance=softhsm-mock-identity-system-2-0-0 --timeout=480s || \
+  { echo "ERROR: SoftHSM mock identity system pod not ready after timeout" >&2; exit 1; }
+
+# Copy chart-generated PKCS11 configmap to esignet-mock namespace
+echo "Copying softhsm-mock-identity-system-share configmap to $ESIGNET_NS"
+$COPY_UTIL configmap softhsm-mock-identity-system-share "$SOFTHSM_NS" "$ESIGNET_NS"
+
+echo "SoftHSM mock identity system post-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/softhsm-mock-identity-system-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/softhsm-mock-identity-system-preinstall.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - SoftHSM Mock Identity System Pre-install
+# =============================================================================
+# Prepares SoftHSM for the mock identity system.
+# =============================================================================
+set -euo pipefail
+
+echo "================================================"
+echo "eSignet 1.7.1 - SoftHSM Mock Identity System Pre-install"
+echo "================================================"
+
+# Ensure softhsm namespace exists
+kubectl create namespace softhsm-2-0-0 --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace softhsm-2-0-0 istio-injection=enabled --overwrite
+
+echo "SoftHSM mock identity system pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/trigger-test-jobs-esignet.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/trigger-test-jobs-esignet.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Trigger Testrig CronJobs
+# =============================================================================
+# Immediately triggers testrig CronJobs after deployment:
+#   apitestrig  → esignet-mock ns   (cronjob-apitestrig-esignet-mock)
+#   signup-apitestrig → signup ns  (if deployed)
+#   signup-uitestrig  → signup-uitestrig ns (if deployed)
+# =============================================================================
+set -euo pipefail
+
+CONTINUE_ON_FAILURE="${CONTINUE_ON_FAILURE:-true}"
+JOB_TIMEOUT="${JOB_TIMEOUT:-5400}"
+OVERALL_SUCCESS=true
+
+trigger_and_wait() {
+  local ns=$1 cronjob=$2
+
+  if ! kubectl get cronjob -n "$ns" "$cronjob" &>/dev/null; then
+    echo "⏭  CronJob $cronjob not found in $ns — skipping"
+    return 0
+  fi
+
+  local job_name="${cronjob}-manual-$(date +%s)"
+  echo "▶ Creating $job_name from $cronjob in $ns"
+  kubectl create job -n "$ns" "$job_name" --from="cronjob/$cronjob"
+
+  local elapsed=0
+  while [[ $elapsed -lt $JOB_TIMEOUT ]]; do
+    local complete=$(kubectl get job -n "$ns" "$job_name" \
+      -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null || echo "")
+    local failed=$(kubectl get job -n "$ns" "$job_name" \
+      -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null || echo "")
+    [[ "$complete" == "True" ]] && { echo "✓ $job_name completed successfully"; return 0; }
+    [[ "$failed"   == "True" ]] && {
+      echo "✗ $job_name failed" >&2
+      kubectl logs -n "$ns" -l "job-name=$job_name" --tail=50 2>/dev/null || true
+      return 1
+    }
+    echo "  ⏳ $job_name running (${elapsed}s elapsed)..."
+    sleep 10
+    elapsed=$((elapsed + 10))
+  done
+
+  echo "✗ $job_name timed out after ${JOB_TIMEOUT}s" >&2
+  return 1
+}
+
+trigger_all_in_ns() {
+  local ns=$1
+  local cronjobs
+  cronjobs=$(kubectl get cronjobs -n "$ns" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+  if [[ -z "$cronjobs" ]]; then
+    echo "⏭  No CronJobs found in $ns — skipping"
+    return 0
+  fi
+  for cj in $cronjobs; do
+    trigger_and_wait "$ns" "$cj" || return 1
+  done
+}
+
+echo "================================================"
+echo "eSignet 1.7.1 - Trigger Testrig CronJobs"
+echo "================================================"
+
+echo "=== eSignet API Testrig (esignet-mock-2-0-0 ns) ==="
+trigger_all_in_ns esignet-mock-2-0-0 || OVERALL_SUCCESS=false
+
+echo "=== eSignet-MOSIPID1 API Testrig (esignet-mosipid1-2-0-0 ns) ==="
+trigger_all_in_ns esignet-mosipid1-2-0-0 || OVERALL_SUCCESS=false
+
+echo "=== eSignet-MOSIPID2 API Testrig (esignet-mosipid2-2-0-0 ns) ==="
+trigger_all_in_ns esignet-mosipid2-2-0-0 || OVERALL_SUCCESS=false
+
+echo "=== eSignet-Sunbird API Testrig (esignet-sunbird-2-0-0 ns) ==="
+trigger_all_in_ns esignet-sunbird-2-0-0 || OVERALL_SUCCESS=false
+
+echo "=== Signup API Testrig (signup-2-0-0 ns, if deployed) ==="
+trigger_all_in_ns signup-2-0-0 || true
+
+echo "=== Signup UI Testrig (signup-uitestrig-2-0-0 ns, if deployed) ==="
+trigger_all_in_ns signup-uitestrig-2-0-0 || true
+
+echo ""
+echo "=== Testrig Execution Summary ==="
+if [[ "$OVERALL_SUCCESS" == "true" ]]; then
+  echo "✓ All testrig jobs completed successfully"
+  exit 0
+else
+  echo "✗ One or more testrig jobs failed"
+  exit 1
+fi

--- a/Helmsman/hooks/esignet-standalone-2.0.0/uitestrig-signup-setup.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/uitestrig-signup-setup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# =============================================================================
+# eSignet 1.7.1 - Signup UI Testrig Pre-install Setup
+# =============================================================================
+# Prepares the signup-uitestrig namespace.
+# Copies keycloak resources from keycloak ns, MinIO s3 secret from minio ns,
+# and postgres-postgresql from postgres ns.
+# Stale uitestrig CMs are deleted so the chart recreates them from set: values.
+# =============================================================================
+set -euo pipefail
+
+NS=signup-uitestrig-2-0-0
+COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
+
+echo "================================================"
+echo "eSignet 1.7.1 - Signup UI Testrig Pre-install"
+echo "================================================"
+
+echo "Ensuring $NS namespace exists with Istio injection disabled"
+kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace "$NS" istio-injection=disabled --overwrite
+
+echo "Deleting stale uitestrig configmaps in $NS"
+kubectl -n "$NS" delete --ignore-not-found=true configmap s3
+kubectl -n "$NS" delete --ignore-not-found=true configmap db
+kubectl -n "$NS" delete --ignore-not-found=true configmap uitestrig
+
+echo "Copying resources to $NS"
+$COPY_UTIL configmap keycloak-host keycloak "$NS"
+$COPY_UTIL secret keycloak-client-secrets keycloak "$NS"
+$COPY_UTIL secret s3 minio "$NS"
+$COPY_UTIL secret postgres-postgresql postgres "$NS"
+
+echo "Signup UI Testrig pre-install setup completed."

--- a/docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md
+++ b/docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md
@@ -11,6 +11,14 @@ You do **not** need to run any commands on your local machine — everything run
 
 **Estimated time:** ~90–120 minutes end to end (Terraform ~30 min, external services ~20 min, eSignet ~25 min).
 
+> **A second, isolated profile — `esignet-standalone-2.0.0`** — is also available in the `profile` dropdown of
+> `helmsman_esignet.yml`, `helmsman_testrigs.yml`, and `helmsman_signup.yml`. It deploys its own namespaces, Helm
+> releases, hostnames (suffixed `-2-0-0`), and databases, so it can run side by side with `esignet-standalone` in
+> the same cluster without colliding. It shares the same external infrastructure (Postgres server, Keycloak, Redis,
+> Kafka, Minio, Captcha instances) and Terraform profile — deploy/manage those via `helmsman_external.yml` and
+> Terraform using the `esignet-standalone` profile as usual; there is no separate `esignet-standalone-2.0.0` entry
+> for either of those.
+
 ---
 
 ## Table of Contents

--- a/terraform/implementations/aws/infra/profiles/esignet-standalone/aws.tfvars
+++ b/terraform/implementations/aws/infra/profiles/esignet-standalone/aws.tfvars
@@ -77,8 +77,11 @@ enable_rancher_import = true
 rancher_import_url    = "\"<rancher-import-url>\""
 
 # DNS Records to map — only eSignet-relevant subdomains
+# Includes hosts for both the esignet-standalone profile and the isolated
+# esignet-standalone-2.0.0 profile (suffixed "-2-0-0"), since both are deployed
+# side-by-side against this same cluster/domain.
 
-subdomain_public   = ["esignet", "healthservices", "signup", "esignet-sunbird", "healthservices-sunbird", "healthservices-mosipid1", "esignet-mosipid1", "pms-mosipid1", "signup-mosipid1", "healthservices-mosipid2", "esignet-mosipid2", "pms-mosipid2", "signup-mosipid2"]
+subdomain_public   = ["esignet", "healthservices", "signup", "esignet-sunbird", "healthservices-sunbird", "healthservices-mosipid1", "esignet-mosipid1", "pms-mosipid1", "signup-mosipid1", "healthservices-mosipid2", "esignet-mosipid2", "pms-mosipid2", "signup-mosipid2", "esignet-2-0-0", "healthservices-2-0-0", "signup-2-0-0", "esignet-sunbird-2-0-0", "healthservices-sunbird-2-0-0", "healthservices-mosipid1-2-0-0", "esignet-mosipid1-2-0-0", "pms-mosipid1-2-0-0", "signup-mosipid1-2-0-0", "healthservices-mosipid2-2-0-0", "esignet-mosipid2-2-0-0", "pms-mosipid2-2-0-0", "signup-mosipid2-2-0-0"]
 subdomain_internal = ["iam", "activemq", "kafka", "kibana", "postgres", "smtp", "pmp", "minio"]
 
 # PostgreSQL Configuration


### PR DESCRIPTION
## Summary

Fixes #302

Adds a second, fully isolated Helmsman profile, `esignet-standalone-2.0.0`, that can be deployed side-by-side with the existing `esignet-standalone` profile in the same cluster without colliding.

## Changes

- New `Helmsman/dsf/esignet-standalone-2.0.0/` (esignet-dsf.yaml, testrigs-dsf.yaml, signup-dsf.yaml) — namespaces, Helm release names, and hostnames all suffixed `-2-0-0` (K8s namespace/release names can't contain dots).
- New `Helmsman/hooks/esignet-standalone-2.0.0/` — hook scripts updated to match, plus isolated Postgres database names and isolated captcha secrets in the shared `captcha` namespace.
- `Helmsman/dsf/esignet-standalone/external-dsf.yaml` — new `databases.*` entries added (pure additions, nothing existing modified) so the isolated profile gets its own databases in the same shared Postgres instance.
- `.github/workflows/helmsman_esignet.yml`, `helmsman_testrigs.yml`, `helmsman_signup.yml` — new `esignet-standalone-2.0.0` profile option added to the dropdown; exact-match `esignet-standalone` conditionals refactored to prefix-matching so both profiles share the same standalone-specific logic.
- `docs/ESIGNET_STANDALONE_DEPLOYMENT_GUIDE.md` — short note on the new profile.

`external-dsf.yaml`/`prereq-dsf.yaml` (shared infra: postgres, redis, kafka, keycloak, captcha, minio) and the Terraform profile stay shared and untouched between both profiles — only the app-layer (eSignet, testrigs, signup) is isolated.

## Known follow-up

The kernel services (`authmanager`, `auditmanager`, `otpmanager`) don't expose their DB connection config in the DSF/hook files — it appears to come from the Helm chart's own default values. The new `mosip_kernel_2_0_0`/`mosip_audit_2_0_0`/`mosip_otp_2_0_0` databases are created, but nothing currently points those specific services at them; needs follow-up with visibility into the chart's values schema.

## Test plan

- [x] `bash -n` on all 56 copied hook scripts
- [x] `actionlint` on the 3 edited workflows (no new warnings vs. base)
- [x] YAML parse validation on all new/modified DSF files
- [x] Regression grep confirming every executable-code namespace/app/hostname reference is suffixed (only comments retain old names)
- [ ] Live `mode=dry-run` trigger of `helmsman_esignet.yml`/`helmsman_testrigs.yml`/`helmsman_signup.yml` with `profile=esignet-standalone-2.0.0` against a real cluster