### PR TITLE
fix(helmsman): copy keycloak resources into esignet-standalone-2.0.0 namespaces

### DIFF
--- a/Helmsman/dsf/esignet-standalone-2.0.0/esignet-dsf.yaml
+++ b/Helmsman/dsf/esignet-standalone-2.0.0/esignet-dsf.yaml
@@ -94,7 +94,7 @@ apps:
     enabled: false
     version: 12.0.1
     chart: mosip/config-server
-    valuesFile: "$WORKDIR/utils/config-server-esignet-values.yaml"
+    valuesFile: "$WORKDIR/utils/esignet-standalone-2.0.0/config-server-esignet-values-2-0-0.yaml"
     wait: true
     timeout: 1200
     priority: -15
@@ -110,7 +110,7 @@ apps:
     enabled: true
     version: 0.0.1-develop
     chart: mosip/esignet
-    valuesFile: "$WORKDIR/utils/esignet-plugin-values.yaml"
+    valuesFile: "$WORKDIR/utils/esignet-standalone-2.0.0/esignet-plugin-values-2-0-0.yaml"
     set:
       image.repository: "mosipqa/esignet-with-plugins"
       image.tag: "develop"
@@ -119,7 +119,7 @@ apps:
       activeProfileEnv: ""
       pluginNameEnv: "esignet-mock-plugin.jar"
       pluginUrlEnv: ""
-      extraEnvVarsCM[0]: "esignet-softhsm-share"
+      extraEnvVarsCM[0]: "esignet-softhsm-2-0-0-share"
       #extraEnvVarsCM[1]: "kafka-config"
       metrics.serviceMonitor.enabled: "false"
       domainConfig.MOSIP_ESIGNET_HOST: "esignet-2-0-0.${domain_name}"
@@ -142,7 +142,7 @@ apps:
     enabled: true
     version: 0.1.0-develop
     chart: mosip/esignet
-    valuesFile: "$WORKDIR/utils/esignet-mosipid1-plugin-values.yaml"
+    valuesFile: "$WORKDIR/utils/esignet-standalone-2.0.0/esignet-mosipid1-plugin-values-2-0-0.yaml"
     set:
       image.repository: "mosipqa/esignet-with-plugins"
       image.tag: "develop"
@@ -151,7 +151,7 @@ apps:
       activeProfileEnv: ""
       pluginNameEnv: "mosip-identity-plugin.jar"
       pluginUrlEnv: ""
-      extraEnvVarsCM[0]: "esignet-softhsm-mosipid1-share"
+      extraEnvVarsCM[0]: "esignet-softhsm-mosipid1-2-0-0-share"
       extraEnvVarsCM[1]: "esignet-global"
       metrics.serviceMonitor.enabled: "false"
       domainConfig.MOSIP_ESIGNET_HOST: "esignet-mosipid1-2-0-0.${domain_name}"
@@ -182,7 +182,7 @@ apps:
     enabled: ${MOSIPID2_ENABLED}
     version: 0.0.1-develop
     chart: mosip/esignet
-    valuesFile: "$WORKDIR/utils/esignet-mosipid2-plugin-values.yaml"
+    valuesFile: "$WORKDIR/utils/esignet-standalone-2.0.0/esignet-mosipid2-plugin-values-2-0-0.yaml"
     set:
       image.repository: "mosipqa/esignet-with-plugins"
       image.tag: "develop"
@@ -191,7 +191,7 @@ apps:
       activeProfileEnv: ""
       pluginNameEnv: "mosip-identity-plugin.jar"
       pluginUrlEnv: ""
-      extraEnvVarsCM[0]: "esignet-softhsm-mosipid2-share"
+      extraEnvVarsCM[0]: "esignet-softhsm-mosipid2-2-0-0-share"
       extraEnvVarsCM[1]: "esignet-global"
       metrics.serviceMonitor.enabled: "false"
       domainConfig.MOSIP_ESIGNET_HOST: "esignet-mosipid2-2-0-0.${domain_name}"
@@ -222,7 +222,7 @@ apps:
     enabled: true
     version: 0.0.1-develop
     chart: mosip/esignet
-    valuesFile: "$WORKDIR/utils/esignet-sunbird-plugin-values.yaml"
+    valuesFile: "$WORKDIR/utils/esignet-standalone-2.0.0/esignet-sunbird-plugin-values-2-0-0.yaml"
     set:
       image.repository: "mosipqa/esignet-with-plugins"
       image.tag: "develop"
@@ -231,7 +231,7 @@ apps:
       activeProfileEnv: ""
       pluginNameEnv: "sunbird-rc-plugin.jar"
       pluginUrlEnv: ""
-      extraEnvVarsCM[0]: "esignet-softhsm-sunbird-share"
+      extraEnvVarsCM[0]: "esignet-softhsm-sunbird-2-0-0-share"
       #extraEnvVarsCM[1]: "kafka-config"
       metrics.serviceMonitor.enabled: "false"
       domainConfig.MOSIP_ESIGNET_HOST: "esignet-sunbird-2-0-0.${domain_name}"
@@ -346,12 +346,12 @@ apps:
     enabled: true
     version: 0.0.1-develop
     chart: mosip/mock-identity-system
-    valuesFile: "$WORKDIR/utils/mock-identity-values.yaml"
+    valuesFile: "$WORKDIR/utils/esignet-standalone-2.0.0/mock-identity-values-2-0-0.yaml"
     set:
       image.repository: "mosipqa/mock-identity-system"
       image.tag: "develop"
       enable_insecure: "false"
-      extraEnvVarsCM[0]: "softhsm-mock-identity-system-share"
+      extraEnvVarsCM[0]: "softhsm-mock-identity-system-2-0-0-share"
       domainConfig.MOSIP_ESIGNET_HOST: "esignet-2-0-0.${domain_name}"
       domainConfig.MOSIP_SIGNUP_HOST: "signup-2-0-0.${domain_name}"
       domainConfig.MOSIP_API_HOST: "api.${domain_name}"
@@ -522,7 +522,7 @@ apps:
       istio.gateways[0]: "pms-partner-mosipid1-gateway"
       istio.corsPolicy.allowOrigins[0].prefix: "https://pms-mosipid1-2-0-0.${domain_name}"
       extraEnvVarsCM[0]: "esignet-global"
-      extraEnvVarsCM[1]: "esignet-config-server-share"
+      extraEnvVarsCM[1]: "esignet-config-server-2-0-0-share"
     priority: -9
     timeout: 1200
     hooks:
@@ -539,7 +539,7 @@ apps:
       istio.gateways[0]: "pms-partner-mosipid1-gateway"
       istio.corsPolicy.allowOrigins[0].prefix: "https://pms-mosipid1-2-0-0.${domain_name}"
       extraEnvVarsCM[0]: "esignet-global"
-      extraEnvVarsCM[1]: "esignet-config-server-share"
+      extraEnvVarsCM[1]: "esignet-config-server-2-0-0-share"
     priority: -9
     timeout: 1200
 
@@ -554,7 +554,7 @@ apps:
       istio.gateways[0]: "pms-partner-mosipid2-gateway"
       istio.corsPolicy.allowOrigins[0].prefix: "https://pms-mosipid2-2-0-0.${domain_name}"
       extraEnvVarsCM[0]: "esignet-global"
-      extraEnvVarsCM[1]: "esignet-config-server-share"
+      extraEnvVarsCM[1]: "esignet-config-server-2-0-0-share"
     priority: -9
     timeout: 1200
     hooks:
@@ -570,7 +570,7 @@ apps:
       # image.tag: "1.2.2.2"
       istio.gateways[0]: "pms-partner-mosipid2-gateway"
       extraEnvVarsCM[0]: "esignet-global"
-      extraEnvVarsCM[1]: "esignet-config-server-share"
+      extraEnvVarsCM[1]: "esignet-config-server-2-0-0-share"
       istio.corsPolicy.allowOrigins[0].prefix: "https://pms-mosipid2-2-0-0.${domain_name}"
     priority: -9
     timeout: 1200     

--- a/Helmsman/hooks/esignet-standalone-2.0.0/config-server-esignet-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/config-server-esignet-postinstall.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 
 SOURCE_NS="esignet-mock-2-0-0"
 COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
-CM_NAME="esignet-config-server-share"
+CM_NAME="esignet-config-server-2-0-0-share"
 
 MOSIPID1_SPRING_LABEL="${ESIGNET_MOSIPID1_SPRING_CONFIG_LABEL:-develop}"
 MOSIPID2_SPRING_LABEL="${ESIGNET_MOSIPID2_SPRING_CONFIG_LABEL:-develop}"

--- a/Helmsman/hooks/esignet-standalone-2.0.0/esignet-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/esignet-preinstall.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 ESIGNET_NS="${ESIGNET_NS:-esignet-mock-2-0-0}"
 POSTGRES_NS="postgres"
 REDIS_NS="redis"
+KEYCLOAK_NS="keycloak"
 COPY_UTIL="$WORKDIR/utils/copy-cm-and-secrets/copy_cm_func.sh"
 
 echo "================================================"
@@ -58,5 +59,25 @@ $COPY_UTIL secret redis "$REDIS_NS" "$ESIGNET_NS"
 # so the 2.0.0 namespace is self-sufficient without touching the shared hook.
 echo "Copying db-common-secrets secret from $POSTGRES_NS"
 $COPY_UTIL secret db-common-secrets "$POSTGRES_NS" "$ESIGNET_NS"
+
+# keycloak-host/keycloak-env-vars/keycloak/keycloak-client-secrets are normally fanned
+# out by esignet-postinstall-keycloak-init.sh (postInstall hook of the shared
+# external-dsf.yaml esignet-keycloak-init release), but that hook's namespace loop only
+# covers the original esignet-standalone namespaces. Copy them directly here so the
+# 2.0.0 namespace is self-sufficient without touching the shared hook. This runs for
+# every instance that delegates to this script (esignet-mock-2-0-0 plus the
+# mosipid1/mosipid2/sunbird wrappers), matching the original profile's fan-out to all
+# four namespaces.
+echo "Copying keycloak-host configmap from $KEYCLOAK_NS"
+$COPY_UTIL configmap keycloak-host "$KEYCLOAK_NS" "$ESIGNET_NS"
+
+echo "Copying keycloak-env-vars configmap from $KEYCLOAK_NS"
+$COPY_UTIL configmap keycloak-env-vars "$KEYCLOAK_NS" "$ESIGNET_NS"
+
+echo "Copying keycloak secret from $KEYCLOAK_NS"
+$COPY_UTIL secret keycloak "$KEYCLOAK_NS" "$ESIGNET_NS"
+
+echo "Copying keycloak-client-secrets secret from $KEYCLOAK_NS"
+$COPY_UTIL secret keycloak-client-secrets "$KEYCLOAK_NS" "$ESIGNET_NS"
 
 echo "eSignet pre-install completed."

--- a/Helmsman/hooks/esignet-standalone-2.0.0/mock-identity-system-preinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/mock-identity-system-preinstall.sh
@@ -5,7 +5,7 @@
 # Prepares esignet namespace for mock identity system deployment:
 #   - Copies softhsm-mock-identity-system secret from softhsm ns
 #   - Creates mockid-postgres-config with mock identity DB values
-#   - Verifies softhsm-mock-identity-system-share ConfigMap is present
+#   - Verifies softhsm-mock-identity-system-2-0-0-share ConfigMap is present
 #
 # Environment Variables:
 #   MOCKID_DB_NAME  - Mock identity DB name (default: mosip_mockidentitysystem)
@@ -50,10 +50,10 @@ kubectl -n "$ESIGNET_NS" create configmap mockid-postgres-config \
 echo "mockid-postgres-config created/updated in $ESIGNET_NS (host=$DB_HOST db=$MOCKID_DB_NAME user=$MOCKID_DB_USER)."
 
 # Verify SoftHSM mock identity configmap exists in esignet namespace
-if kubectl -n "$ESIGNET_NS" get configmap softhsm-mock-identity-system-share &>/dev/null; then
+if kubectl -n "$ESIGNET_NS" get configmap softhsm-mock-identity-system-2-0-0-share &>/dev/null; then
   echo "SoftHSM mock identity system configmap found."
 else
-  echo "ERROR: softhsm-mock-identity-system-share configmap not found in $ESIGNET_NS namespace."
+  echo "ERROR: softhsm-mock-identity-system-2-0-0-share configmap not found in $ESIGNET_NS namespace."
   echo "Deploy softhsm-mock-identity-system-2-0-0 before running mock identity system install."
   exit 1
 fi

--- a/Helmsman/hooks/esignet-standalone-2.0.0/softhsm-mock-identity-system-postinstall.sh
+++ b/Helmsman/hooks/esignet-standalone-2.0.0/softhsm-mock-identity-system-postinstall.sh
@@ -2,7 +2,7 @@
 # =============================================================================
 # eSignet 1.7.1 - SoftHSM Mock Identity System Post-install
 # =============================================================================
-# Copies chart-generated softhsm-mock-identity-system-share configmap
+# Copies chart-generated softhsm-mock-identity-system-2-0-0-share configmap
 # (PKCS11 slot/token config) from softhsm namespace to esignet-mock namespace.
 # The security PIN is handled separately via secret copy in preinstall.
 # =============================================================================
@@ -21,7 +21,7 @@ kubectl -n "$SOFTHSM_NS" wait --for=condition=ready pod -l app.kubernetes.io/ins
   { echo "ERROR: SoftHSM mock identity system pod not ready after timeout" >&2; exit 1; }
 
 # Copy chart-generated PKCS11 configmap to esignet-mock namespace
-echo "Copying softhsm-mock-identity-system-share configmap to $ESIGNET_NS"
-$COPY_UTIL configmap softhsm-mock-identity-system-share "$SOFTHSM_NS" "$ESIGNET_NS"
+echo "Copying softhsm-mock-identity-system-2-0-0-share configmap to $ESIGNET_NS"
+$COPY_UTIL configmap softhsm-mock-identity-system-2-0-0-share "$SOFTHSM_NS" "$ESIGNET_NS"
 
 echo "SoftHSM mock identity system post-install completed."

--- a/Helmsman/utils/esignet-standalone-2.0.0/config-server-esignet-values-2-0-0.yaml
+++ b/Helmsman/utils/esignet-standalone-2.0.0/config-server-esignet-values-2-0-0.yaml
@@ -1,0 +1,139 @@
+# Config-server values for eSignet standalone profile.
+# Based on: esignet/deploy/config-server/values.yaml
+#
+# Domain values (API_HOST, ESIGNET_HOST, etc.) are read from the
+# esignet-global ConfigMap created by config-server-esignet-setup.sh
+# from workflow env vars — no static domain values here.
+#
+# envVariables is a Helm list — this file is the single source of truth for
+# all entries. Do NOT partially override via a second -f file; it replaces
+# the whole list.
+
+gitRepo:
+  uri: https://github.com/mosip/mosip-config
+  version: esqa-2
+  searchFolders: ""
+  private: false
+  username: ""
+  token: ""
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 400m
+    memory: 2000Mi
+  requests:
+    cpu: 200m
+    memory: 1500Mi
+
+envVariables:
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_DB_DBUSER_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: db-common-secrets
+        key: db-dbuser-password
+    enabled: true
+
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_API_PUBLIC_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: esignet-global
+        key: mosip-api-host
+    enabled: true
+
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_API_INTERNAL_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: esignet-global
+        key: mosip-api-internal-host
+    enabled: true
+
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_KEYCLOAK_INTERNAL_URL
+    valueFrom:
+      configMapKeyRef:
+        name: keycloak-host
+        key: keycloak-internal-url
+    enabled: true
+
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_KEYCLOAK_EXTERNAL_URL
+    valueFrom:
+      configMapKeyRef:
+        name: keycloak-host
+        key: keycloak-external-url
+    enabled: true
+
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_ESIGNET_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: esignet-global
+        key: mosip-esignet-host
+    enabled: true
+
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_KEYCLOAK_INTERNAL_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: keycloak-host
+        key: keycloak-internal-host
+    enabled: true
+
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_KEYCLOAK_EXTERNAL_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: keycloak-host
+        key: keycloak-external-host
+    enabled: true
+
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MPARTNER_DEFAULT_AUTH_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: keycloak-client-secrets
+        key: mpartner_default_auth_secret
+    enabled: true
+
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_SOFTHSM_ESIGNET_SECURITY_PIN
+    valueFrom:
+      secretKeyRef:
+        name: esignet-softhsm-2-0-0
+        key: security-pin
+    enabled: true
+
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_ESIGNET_CAPTCHA_SECRET_KEY
+    valueFrom:
+      secretKeyRef:
+        name: esignet-captcha-2-0-0
+        key: esignet-captcha-secret-key
+    enabled: true
+
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_ESIGNET_CAPTCHA_SITE_KEY
+    valueFrom:
+      secretKeyRef:
+        name: esignet-captcha-2-0-0
+        key: esignet-captcha-site-key
+    enabled: true
+
+  # Placeholder until MISP onboarder runs (priority -6).
+  # After onboarder writes the real key, config-server is restarted by
+  # esignet-misp-onboarder-postinstall.sh so the updated secret is loaded.
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_ESIGNET_MISP_KEY
+    valueFrom:
+      secretKeyRef:
+        name: esignet-misp-onboarder-key
+        key: mosip-esignet-misp-key
+    enabled: true
+
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_PMS_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: keycloak-client-secrets
+        key: mosip_pms_client_secret
+    enabled: true
+
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_SIGNUP_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: esignet-global
+        key: mosip-signup-host
+    enabled: true

--- a/Helmsman/utils/esignet-standalone-2.0.0/esignet-mosipid1-plugin-values-2-0-0.yaml
+++ b/Helmsman/utils/esignet-standalone-2.0.0/esignet-mosipid1-plugin-values-2-0-0.yaml
@@ -1,0 +1,119 @@
+# eSignet MOSIPID1 — plugin 2 (mosip-identity-plugin) runtime configuration.
+# pluginNameEnv=mosip-identity-plugin.jar set in DSF set: block.
+# Update IDA service URLs below to match your MOSIP IDA deployment.
+
+# Override full extraEnvVars to use namespace-specific softhsm secret name.
+extraEnvVars:
+  - name: KEYCLOAK_EXTERNAL_URL
+    valueFrom:
+      configMapKeyRef:
+        name: keycloak-host
+        key: keycloak-external-url
+  - name: MOSIP_ESIGNET_CAPTCHA_MODULE_NAME
+    value: esignet
+  - name: REDIS_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: redis-config
+        key: redis-host
+  - name: REDIS_PORT
+    valueFrom:
+      configMapKeyRef:
+        name: redis-config
+        key: redis-port
+  - name: REDIS_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: redis
+        key: redis-password
+  - name: DATABASE_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: postgres-config
+        key: database-host
+  - name: DATABASE_PORT
+    valueFrom:
+      configMapKeyRef:
+        name: postgres-config
+        key: database-port
+  - name: DATABASE_NAME
+    valueFrom:
+      configMapKeyRef:
+        name: postgres-config
+        key: database-name
+  - name: DATABASE_USERNAME
+    valueFrom:
+      configMapKeyRef:
+        name: postgres-config
+        key: database-username
+  - name: DB_DBUSER_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: db-common-secrets
+        key: db-dbuser-password
+  - name: SOFTHSM_ESIGNET_SECURITY_PIN
+    valueFrom:
+      secretKeyRef:
+        name: esignet-softhsm-mosipid1-2-0-0
+        key: security-pin
+  - name: MOSIP_IDA_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: keycloak-client-secrets-mosipid1
+        key: mosip_ida_client_secret
+
+extraEnvVarsAdditional:
+  - name: "MOSIP_ESIGNET_CAPTCHA_MODULE_NAME"
+    value: "esignetmosipid1"
+  - name: "MOSIP_ESIGNET_CAPTCHA_SITE-KEY"
+    valueFrom:
+      secretKeyRef:
+        name: esignet-captcha-mosipid1-2-0-0
+        key: esignet-captcha-site-key
+
+  # ---------------------------------------------------------------------------
+  # Plugin 2: mosip-identity-plugin
+  # Update URLs to match your MOSIP IDA deployment.
+  # ---------------------------------------------------------------------------
+  - name: NAMESPACE
+    value: mosipid1
+  - name: plugin_name_env
+    value: mosip-identity-plugin.jar
+  - name: SPRING_KAFKA_CONSUMER_GROUP_ID
+    value: esignet-consumer-esignet-mosipid1
+  - name: MOSIP_ESIGNET_SIGNUP_ID_TOKEN_AUDIENCE
+    value: esignet-mosipid1-signup-esqa020
+  - name: MOSIP_ESIGNET_AUTHENTICATOR_IDA_OTP_CHANNELS
+    value: email,phone
+  - name: MOSIP_ESIGNET_SEND_OTP_ATTEMPTS
+    value: '300'
+  - name: MOSIP_ESIGNET_AUTHENTICATE_ATTEMPTS
+    value: '300'
+  - name: MOSIP_ESIGNET_AUTHENTICATION_EXPIRE_IN_SECS
+    value: '600'
+  - name: MOSIP_ESIGNET_PREAUTHENTICATION_EXPIRE_IN_SECS
+    value: '600'
+  - name: MOSIP_ESIGNET_UI_CONFIG_USERNAME_POSTFIX
+    value: '@phone'
+  - name: MOSIP_ESIGNET_UI_CONFIG_LOGIN_ID_OPTIONS
+    value: >-
+      {{ "{{" }} 'id': 'mobile', 'svg': 'mobile_icon', 'prefixes': {{ "{{" }}'label':
+      'IND', 'value': '+91', 'maxLength': '', 'regex': ''},{'label':
+      'KHM', 'value': '+855', 'regex': ''{{ "}}" }}, 'postfix': '@phone',
+      'maxLength': '', 'regex': '' }, { 'id': 'nrc', 'svg':
+      'nrc_id_icon', 'prefixes': '', 'postfix': '@nrc', 'maxLength':
+      '', 'regex': '' }, { 'id': 'vid', 'svg': 'vid_icon', 'prefixes':
+      '', 'postfix': '', 'maxLength': '', 'regex': '' }, { 'id':
+      'email', 'svg': 'email_icon', 'prefixes': '', 'postfix':
+      '@email', 'maxLength': '', 'regex': '' {{ "}}" }}
+  - name: LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_WEB_CLIENT
+    value: DEBUG
+  - name: MOSIP_ESIGNET_CAPTCHA_REQUIRED
+    value: "false"
+  - name: MOSIP_ESIGNET_CAPTCHA_URL
+    value: http://captcha.captcha    
+  - name: "MOSIP_ESIGNET_MISP_KEY"
+    valueFrom:
+      secretKeyRef:
+        name: esignet-misp-onboarder-key
+        key: mosip-esignet-misp-key

--- a/Helmsman/utils/esignet-standalone-2.0.0/esignet-mosipid2-plugin-values-2-0-0.yaml
+++ b/Helmsman/utils/esignet-standalone-2.0.0/esignet-mosipid2-plugin-values-2-0-0.yaml
@@ -1,0 +1,118 @@
+# eSignet MOSIPID2 — plugin 2 (mosip-identity-plugin) runtime configuration.
+# pluginNameEnv=mosip-identity-plugin.jar set in DSF set: block.
+# Update IDA service URLs below to match your MOSIP IDA deployment.
+
+# Override full extraEnvVars to use namespace-specific softhsm secret name.
+extraEnvVars:
+  - name: KEYCLOAK_EXTERNAL_URL
+    valueFrom:
+      configMapKeyRef:
+        name: keycloak-host
+        key: keycloak-external-url
+  - name: REDIS_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: redis-config
+        key: redis-host
+  - name: REDIS_PORT
+    valueFrom:
+      configMapKeyRef:
+        name: redis-config
+        key: redis-port
+  - name: REDIS_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: redis
+        key: redis-password
+  - name: DATABASE_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: postgres-config
+        key: database-host
+  - name: DATABASE_PORT
+    valueFrom:
+      configMapKeyRef:
+        name: postgres-config
+        key: database-port
+  - name: DATABASE_NAME
+    valueFrom:
+      configMapKeyRef:
+        name: postgres-config
+        key: database-name
+  - name: DATABASE_USERNAME
+    valueFrom:
+      configMapKeyRef:
+        name: postgres-config
+        key: database-username
+  - name: DB_DBUSER_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: db-common-secrets
+        key: db-dbuser-password
+  - name: SOFTHSM_ESIGNET_SECURITY_PIN
+    valueFrom:
+      secretKeyRef:
+        name: esignet-softhsm-mosipid2-2-0-0
+        key: security-pin
+  - name: MOSIP_IDA_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: keycloak-client-secrets-mosipid2
+        key: mosip_ida_client_secret
+
+extraEnvVarsAdditional:
+  - name: "MOSIP_ESIGNET_CAPTCHA_MODULE_NAME"
+    value: "esignetmosipid2"
+  - name: "MOSIP_ESIGNET_CAPTCHA_SITE-KEY"
+    valueFrom:
+      secretKeyRef:
+        name: esignet-captcha-mosipid2-2-0-0
+        key: esignet-captcha-site-key
+
+  # ---------------------------------------------------------------------------
+  # Plugin 2: mosip-identity-plugin
+  # Update URLs to match your MOSIP IDA deployment.
+  # ---------------------------------------------------------------------------
+  - name: NAMESPACE
+    value: mosipid2
+  - name: plugin_name_env
+    value: mosip-identity-plugin.jar
+  - name: SPRING_KAFKA_CONSUMER_GROUP_ID
+    value: esignet-consumer-esignet-mosipid2
+  - name: MOSIP_ESIGNET_SIGNUP_ID_TOKEN_AUDIENCE
+    value: esignet-mosipid2-signup-esqa020
+  - name: MOSIP_ESIGNET_AUTHENTICATOR_IDA_OTP_CHANNELS
+    value: email,phone
+  - name: MOSIP_ESIGNET_SEND_OTP_ATTEMPTS
+    value: '300'
+  - name: MOSIP_ESIGNET_AUTHENTICATE_ATTEMPTS
+    value: '300'
+  - name: MOSIP_ESIGNET_AUTHENTICATION_EXPIRE_IN_SECS
+    value: '600'
+  - name: MOSIP_ESIGNET_PREAUTHENTICATION_EXPIRE_IN_SECS
+    value: '600'
+  - name: MOSIP_ESIGNET_UI_CONFIG_USERNAME_POSTFIX
+    value: '@phone'
+  - name: MOSIP_ESIGNET_UI_CONFIG_LOGIN_ID_OPTIONS
+    value: >-
+      {{ "{{" }} 'id': 'mobile', 'svg': 'mobile_icon', 'prefixes': {{ "{{" }}'label':
+      'IND', 'value': '+91', 'maxLength': '', 'regex': ''},{'label':
+      'KHM', 'value': '+855', 'regex': ''{{ "}}" }}, 'postfix': '@phone',
+      'maxLength': '', 'regex': '' }, { 'id': 'nrc', 'svg':
+      'nrc_id_icon', 'prefixes': '', 'postfix': '@nrc', 'maxLength':
+      '', 'regex': '' }, { 'id': 'vid', 'svg': 'vid_icon', 'prefixes':
+      '', 'postfix': '', 'maxLength': '', 'regex': '' }, { 'id':
+      'email', 'svg': 'email_icon', 'prefixes': '', 'postfix':
+      '@email', 'maxLength': '', 'regex': '' {{ "}}" }}
+  - name: LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_WEB_CLIENT
+    value: DEBUG
+  - name: MOSIP_ESIGNET_CAPTCHA_REQUIRED
+    value: ""
+  - name: MOSIP_ESIGNET_CAPTCHA_URL
+    value: http://captcha.captcha
+  - name: "MOSIP_ESIGNET_MISP_KEY"
+    valueFrom:
+      secretKeyRef:
+        name: esignet-misp-onboarder-key
+        key: mosip-esignet-misp-key
+

--- a/Helmsman/utils/esignet-standalone-2.0.0/esignet-plugin-values-2-0-0.yaml
+++ b/Helmsman/utils/esignet-standalone-2.0.0/esignet-plugin-values-2-0-0.yaml
@@ -1,0 +1,147 @@
+# eSignet standalone — plugin and captcha runtime configuration.
+#
+# Plugin selection:
+#   Plugin 1 (mock):            pluginNameEnv=esignet-mock-plugin.jar  → no changes needed here
+#   Plugin 2 (mosip-identity):  pluginNameEnv=mosip-identity-plugin.jar → uncomment IDA section below
+#   Plugin 3 (sunbird-rc):      pluginNameEnv=sunbird-rc-plugin.jar    → uncomment Sunbird section below
+#   Plugin 4 (custom):          pluginNameEnv=<your-jar> pluginUrlEnv=<url> → no changes needed here
+#
+
+## Uncomment required parms added with single '#' when needed.
+
+
+extraEnvVars:
+ - name: KEYCLOAK_EXTERNAL_URL
+   valueFrom:
+     configMapKeyRef:
+       name: keycloak-host
+       key: keycloak-external-url
+ - name: MOSIP_ESIGNET_CAPTCHA_SITE_KEY
+   valueFrom:
+     secretKeyRef:
+       name: esignet-captcha-2-0-0
+       key: esignet-captcha-site-key
+ - name: MOSIP_ESIGNET_CAPTCHA_MODULE_NAME
+   value: esignet
+ - name: REDIS_HOST
+   valueFrom:
+     configMapKeyRef:
+       name: redis-config
+       key: redis-host
+ - name: REDIS_PORT
+   valueFrom:
+     configMapKeyRef:
+       name: redis-config
+       key: redis-port
+ - name: REDIS_PASSWORD
+   valueFrom:
+     secretKeyRef:
+       name: redis
+       key: redis-password
+ - name: DATABASE_HOST
+   valueFrom:
+     configMapKeyRef:
+       name: postgres-config
+       key: database-host
+ - name: DATABASE_PORT
+   valueFrom:
+     configMapKeyRef:
+       name: postgres-config
+       key: database-port
+ - name: DATABASE_NAME
+   valueFrom:
+     configMapKeyRef:
+       name: postgres-config
+       key: database-name
+ - name: DATABASE_USERNAME
+   valueFrom:
+     configMapKeyRef:
+       name: postgres-config
+       key: database-username
+ - name: DB_DBUSER_PASSWORD
+   valueFrom:
+     secretKeyRef:
+       name: db-common-secrets
+       key: db-dbuser-password
+ - name: SOFTHSM_ESIGNET_SECURITY_PIN
+   valueFrom:
+     secretKeyRef:
+       name: esignet-softhsm-2-0-0
+       key: security-pin
+ - name: MOSIP_IDA_CLIENT_SECRET
+   valueFrom:
+     secretKeyRef:
+       name: keycloak-client-secrets
+       key: mosip_ida_client_secret
+
+# extraEnvVarsCM:
+#  - esignet-softhsm-share
+
+#extraEnvVarsSecret: []
+
+#istio:
+#  enabled: true
+#  gateways:
+#    - istio-system/public
+#    - istio-system/internal
+#  prefix: /v1/esignet/
+
+
+
+# extraEnvVarsAdditional is a Helm list — this file REPLACES the base list on merge.
+# All required entries (captcha + plugin-specific) must be present together.
+
+extraEnvVarsAdditional:
+  # Captcha site key — from esignet-captcha secret (deployed by external-dsf)
+  - name: "MOSIP_ESIGNET_CAPTCHA_SITE_KEY"
+    valueFrom:
+      secretKeyRef:
+        name: esignet-captcha-2-0-0
+        key: esignet-captcha-site-key
+  - name: "MOSIP_ESIGNET_CAPTCHA_REQUIRED"
+    value: ""
+
+  # ---------------------------------------------------------------------------
+  # Plugin 2: mosip-identity-plugin
+  # Uncomment all entries below when pluginNameEnv=mosip-identity-plugin.jar.
+  # Update URLs to match your MOSIP IDA deployment if the defaults don't apply.
+  # ---------------------------------------------------------------------------
+  #
+  # - name: "MOSIP_ESIGNET_AUTHENTICATOR_IDA_CERT_URL"
+  #   value: "http://mosip-file-server.mosip-file-server/mosip-certs/ida-partner.cer"
+  # - name: "MOSIP_ESIGNET_AUTHENTICATOR_IDA_KYC-AUTH-URL"
+  #   value: "http://ida-auth.ida/idauthentication/v1/kyc-auth/delegated/${mosip.esignet.authenticator.ida.misp-license-key}/"
+  # - name: "MOSIP_ESIGNET_AUTHENTICATOR_IDA_KYC-EXCHANGE-URL"
+  #   value: "http://ida-auth.ida/idauthentication/v1/kyc-exchange/delegated/${mosip.esignet.authenticator.ida.misp-license-key}/"
+  # - name: "MOSIP_ESIGNET_AUTHENTICATOR_IDA_SEND-OTP-URL"
+  #   value: "http://ida-otp.ida/idauthentication/v1/otp/${mosip.esignet.authenticator.ida.misp-license-key}/"
+  # - name: "MOSIP_ESIGNET_BINDER_IDA_KEY-BINDING-URL"
+  #   value: "http://ida-auth.ida/idauthentication/v1/identity-key-binding/delegated/${mosip.esignet.authenticator.ida.misp-license-key}/"
+  # - name: "MOSIP_ESIGNET_AUTHENTICATOR_IDA_GET-CERTIFICATES-URL"
+  #   value: "http://ida-internal.ida/idauthentication/v1/internal/getAllCertificates"
+  # - name: "MOSIP_ESIGNET_AUTHENTICATOR_IDA_AUTH-TOKEN-URL"
+  #   value: "http://authmanager.kernel/v1/authmanager/authenticate/clientidsecretkey"
+  # - name: "MOSIP_ESIGNET_AUTHENTICATOR_IDA_AUDIT-MANAGER-URL"
+  #   value: "http://auditmanager.kernel/v1/auditmanager/audits"
+  # - name: "MOSIP_ESIGNET_AUTHENTICATOR_IDA_OTP-CHANNELS"
+  #   value: "email,phone"
+  # - name: "MOSIP_ESIGNET_MISP_KEY"
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: esignet-misp-onboarder-key
+  #       key: mosip-esignet-misp-key
+
+  # ---------------------------------------------------------------------------
+  # Plugin 3: sunbird-rc-plugin
+  # Uncomment all entries below when pluginNameEnv=sunbird-rc-plugin.jar.
+  # Set MOSIP_ESIGNET_SUNBIRD_RC_REGISTRY_GET_URL to your Sunbird registry host.
+  # ---------------------------------------------------------------------------
+  #
+  # - name: "MOSIP_ESIGNET_SUNBIRD_RC_REGISTRY_GET_URL"
+  #   value: "https://your-sunbird-registry-host"
+  # - name: "MOSIP_ESIGNET_AUTHENTICATOR_SUNBIRD_RC_AUTH_FACTOR_KBI_REGISTRY_SEARCH_URL"
+  #   value: "https://your-sunbird-registry-host/api/v1/Insurance/search"
+  # - name: "MOSIP_ESIGNET_INTEGRATION_AUDIT_PLUGIN"
+  #   value: "LoggerAuditService"
+  # - name: "MOSIP_ESIGNET_INTEGRATION_KEY_BINDER"
+  #   value: "NoOpKeyBinder"

--- a/Helmsman/utils/esignet-standalone-2.0.0/esignet-sunbird-plugin-values-2-0-0.yaml
+++ b/Helmsman/utils/esignet-standalone-2.0.0/esignet-sunbird-plugin-values-2-0-0.yaml
@@ -1,0 +1,85 @@
+# eSignet Sunbird — plugin 3 (sunbird-rc-plugin) runtime configuration.
+# pluginNameEnv=sunbird-rc-plugin.jar set in DSF set: block.
+# Update MOSIP_ESIGNET_SUNBIRD_RC_REGISTRY_GET_URL to your Sunbird registry host.
+
+# Override full extraEnvVars to use namespace-specific softhsm secret name.
+extraEnvVars:
+  - name: KEYCLOAK_EXTERNAL_URL
+    valueFrom:
+      configMapKeyRef:
+        name: keycloak-host
+        key: keycloak-external-url
+  - name: MOSIP_ESIGNET_CAPTCHA_MODULE_NAME
+    value: esignet
+  - name: REDIS_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: redis-config
+        key: redis-host
+  - name: REDIS_PORT
+    valueFrom:
+      configMapKeyRef:
+        name: redis-config
+        key: redis-port
+  - name: REDIS_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: redis
+        key: redis-password
+  - name: DATABASE_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: postgres-config
+        key: database-host
+  - name: DATABASE_PORT
+    valueFrom:
+      configMapKeyRef:
+        name: postgres-config
+        key: database-port
+  - name: DATABASE_NAME
+    valueFrom:
+      configMapKeyRef:
+        name: postgres-config
+        key: database-name
+  - name: DATABASE_USERNAME
+    valueFrom:
+      configMapKeyRef:
+        name: postgres-config
+        key: database-username
+  - name: DB_DBUSER_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: db-common-secrets
+        key: db-dbuser-password
+  - name: SOFTHSM_ESIGNET_SECURITY_PIN
+    valueFrom:
+      secretKeyRef:
+        name: esignet-softhsm-sunbird-2-0-0
+        key: security-pin
+  - name: MOSIP_IDA_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: keycloak-client-secrets
+        key: mosip_ida_client_secret
+
+extraEnvVarsAdditional:
+  - name: "MOSIP_ESIGNET_CAPTCHA_SITE_KEY"
+    valueFrom:
+      secretKeyRef:
+        name: esignet-captcha-sunbird-2-0-0
+        key: esignet-captcha-site-key
+  - name: "MOSIP_ESIGNET_CAPTCHA_REQUIRED"
+    value: ""
+
+  # ---------------------------------------------------------------------------
+  # Plugin 3: sunbird-rc-plugin
+  # Update URLs to match your Sunbird RC registry deployment.
+  # ---------------------------------------------------------------------------
+  - name: "MOSIP_ESIGNET_INTEGRATION_AUDIT_PLUGIN"
+    value: "LoggerAuditService"
+  - name: "MOSIP_ESIGNET_INTEGRATION_KEY_BINDER"
+    value: "NoOpKeyBinder"
+  - name: MOSIP_ESIGNET_AUTHENTICATE_ATTEMPTS
+    value: '300'
+  - name: MOSIP_ESIGNET_AUTHENTICATOR_DEFAULT_AUTH_FACTOR_KBI_INDIVIDUAL_ID_FIELD
+    value: "policyNumber"

--- a/Helmsman/utils/esignet-standalone-2.0.0/mock-identity-values-2-0-0.yaml
+++ b/Helmsman/utils/esignet-standalone-2.0.0/mock-identity-values-2-0-0.yaml
@@ -1,0 +1,50 @@
+extraEnvVars:
+  - name: DATABASE_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: mockid-postgres-config
+        key: database-host
+  - name: DATABASE_PORT
+    valueFrom:
+      configMapKeyRef:
+        name: mockid-postgres-config
+        key: database-port
+  - name: DATABASE_NAME
+    valueFrom:
+      configMapKeyRef:
+        name: mockid-postgres-config
+        key: database-name
+  - name: DATABASE_USERNAME
+    valueFrom:
+      configMapKeyRef:
+        name: mockid-postgres-config
+        key: database-username
+  - name: DB_DBUSER_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: db-common-secrets
+        key: db-dbuser-password
+  - name: SOFTHSM_MOCK_IDENTITY_SYSTEM_SECURITY_PIN
+    valueFrom:
+      secretKeyRef:
+        name: softhsm-mock-identity-system-2-0-0
+        key: security-pin
+  - name: hsm_local_dir_name
+    value: hsm-client
+  - name: MOSIP_ESIGNET_MOCK_SUPPORTED_FIELDS
+    value: individualId,password
+  - name: REDIS_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: redis-config
+        key: redis-host
+  - name: REDIS_PORT
+    valueFrom:
+      configMapKeyRef:
+        name: redis-config
+        key: redis-port
+  - name: REDIS_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: redis
+        key: redis-password


### PR DESCRIPTION
## Summary

Fixes #302

Follow-up to #303/#304. The shared `external-dsf.yaml`'s `esignet-keycloak-init` release runs `esignet-postinstall-keycloak-init.sh` as its postInstall hook, which fans out `keycloak-host` (CM), `keycloak-env-vars` (CM), `keycloak` (secret), and `keycloak-client-secrets` (secret) from the shared `keycloak` namespace — but only to the original `esignet-standalone` namespaces (`esignet-mock`, `esignet-mosipid1`, `esignet-mosipid2`, `esignet-sunbird`). Since `external-dsf.yaml` isn't duplicated for the isolated `esignet-standalone-2.0.0` profile, those 4 objects never landed in the `-2-0-0` namespaces.

This is a real deployment blocker: `esignet-misp-onboarder-2-0-0` and `esignet-mock-rp-onboarder-2-0-0` (in `esignet-mock-2-0-0`) explicitly reference `keycloak-env-vars`, `keycloak-host`, `keycloak`, and `keycloak-client-secrets` via `extraEnvVarsCM`/`extraEnvVarsSecret` — none of which would exist without this fix.

## Fix

Added the same 4 copy operations directly to `Helmsman/hooks/esignet-standalone-2.0.0/esignet-preinstall.sh` (mirroring the shared hook's logic exactly, same object names, same source namespace). Since `esignet-mosipid1-preinstall.sh`/`esignet-mosipid2-preinstall.sh`/`esignet-sunbird-preinstall.sh` all delegate to this script first, all four `-2-0-0` namespaces get these objects copied in — matching the original profile's fan-out to all four namespaces, without touching `external-dsf.yaml` or its shared hook.

## Test plan

- [x] `bash -n` syntax check
- [x] Confirmed all 4 `-2-0-0` instances delegate through `esignet-preinstall.sh` and therefore receive the copy
- [ ] Re-trigger `helmsman_esignet.yml` with `profile=esignet-standalone-2.0.0` to confirm the onboarder apps start successfully