### PR TITLE
fix: YAML indentation bug + remove OIDC_UI_HOSTNAME from esignet-standalone-2.0.0 plugin values (#302)

### DIFF
--- a/Helmsman/utils/esignet-standalone-2.0.0/esignet-mosipid1-plugin-values-2-0-0.yaml
+++ b/Helmsman/utils/esignet-standalone-2.0.0/esignet-mosipid1-plugin-values-2-0-0.yaml
@@ -71,11 +71,6 @@ extraEnvVars:
     value: https
   - name: CRYPTO_ENCRYPTION_KEY
     value: 0579f866ac7c9273580d0ff163fa01a7b2401a7ff3ddc3e3b14ae3136fa6025e
-  - name: OIDC_UI_HOSTNAME
-    valueFrom:
-      configMapKeyRef:
-        name: esignet-global
-        key: mosip-esignet-host
   - name: OIDC_UI_PORT
     value: '443'
   - name: OIDC_UI_LOGIN_PATH

--- a/Helmsman/utils/esignet-standalone-2.0.0/esignet-mosipid2-plugin-values-2-0-0.yaml
+++ b/Helmsman/utils/esignet-standalone-2.0.0/esignet-mosipid2-plugin-values-2-0-0.yaml
@@ -69,11 +69,6 @@ extraEnvVars:
     value: https
   - name: CRYPTO_ENCRYPTION_KEY
     value: 0579f866ac7c9273580d0ff163fa01a7b2401a7ff3ddc3e3b14ae3136fa6025e
-  - name: OIDC_UI_HOSTNAME
-    valueFrom:
-      configMapKeyRef:
-        name: esignet-global
-        key: mosip-esignet-host
   - name: OIDC_UI_PORT
     value: '443'
   - name: OIDC_UI_LOGIN_PATH

--- a/Helmsman/utils/esignet-standalone-2.0.0/esignet-plugin-values-2-0-0.yaml
+++ b/Helmsman/utils/esignet-standalone-2.0.0/esignet-plugin-values-2-0-0.yaml
@@ -73,33 +73,28 @@ extraEnvVars:
      secretKeyRef:
        name: keycloak-client-secrets
        key: mosip_ida_client_secret
-  - name: AUTHN_PROVIDER
-    value: mosip
-  - name: MOSIP_P12_PATH
-    value: /home/mosip/keys/secret/esignet.pfx
-  - name: MOSIP_P12_PASSWORD
-    value: localtest
-  - name: OIDC_UI_SCHEME
-    value: https
-  - name: CRYPTO_ENCRYPTION_KEY
-    value: 0579f866ac7c9273580d0ff163fa01a7b2401a7ff3ddc3e3b14ae3136fa6025e
-  - name: OIDC_UI_HOSTNAME
-    valueFrom:
-      configMapKeyRef:
-        name: esignet-global
-        key: mosip-esignet-host
-  - name: OIDC_UI_PORT
-    value: '443'
-  - name: OIDC_UI_LOGIN_PATH
-    value: /signin
-  - name: OIDC_UI_ERROR_PATH
-    value: /error
-  - name: DEFAULT_THEME_ID
-    value: decl-theme-1
-  - name: DEFAULT_LAYOUT_ID
-    value: decl-layout-1
-  - name: DEFAULT_AUTH_FLOW_ID
-    value: decl-mosip-otp-flow-1
+ - name: AUTHN_PROVIDER
+   value: mosip
+ - name: MOSIP_P12_PATH
+   value: /home/mosip/keys/secret/esignet.pfx
+ - name: MOSIP_P12_PASSWORD
+   value: localtest
+ - name: OIDC_UI_SCHEME
+   value: https
+ - name: CRYPTO_ENCRYPTION_KEY
+   value: 0579f866ac7c9273580d0ff163fa01a7b2401a7ff3ddc3e3b14ae3136fa6025e
+ - name: OIDC_UI_PORT
+   value: '443'
+ - name: OIDC_UI_LOGIN_PATH
+   value: /signin
+ - name: OIDC_UI_ERROR_PATH
+   value: /error
+ - name: DEFAULT_THEME_ID
+   value: decl-theme-1
+ - name: DEFAULT_LAYOUT_ID
+   value: decl-layout-1
+ - name: DEFAULT_AUTH_FLOW_ID
+   value: decl-mosip-otp-flow-1
 # extraEnvVarsCM:
 #  - esignet-softhsm-share
 


### PR DESCRIPTION
## Summary
- Fixes a YAML parse error (`did not find expected '-' indicator`) in `esignet-plugin-values-2-0-0.yaml` that broke `esignet-go-mock` deployment. The chart-versions update had appended new `extraEnvVars` entries at 2-space indentation while the rest of the file's list uses 1-space indentation — a single YAML block sequence can't mix indent widths.
- Removes the `OIDC_UI_HOSTNAME` env var entry (sourced from the `esignet-global` configmap) from the base, mosipid1, and mosipid2 plugin-values files in the `esignet-standalone-2.0.0` profile.

Refs #302

## Test plan
- [x] `ruby -ryaml` parse check on all edited files
- [x] Verified `extraEnvVars` parses as a single combined list (25/24/23 entries) with all expected keys present
- [x] Grepped for zero remaining `OIDC_UI_HOSTNAME` occurrences in the profile
- [ ] Live deploy of `esignet-standalone-2.0.0` against a test cluster to confirm `esignet-go-mock` installs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)