### PR TITLE
fix: make mosipid2_domain_name optional in helmsman_testrigs.yml (#302)

### DIFF
--- a/.github/workflows/helmsman_testrigs.yml
+++ b/.github/workflows/helmsman_testrigs.yml
@@ -29,8 +29,13 @@ on:
         description: "MOSIP-ID1 domain name (e.g. mosipenv1.xyz.net) — required for esignet profile"
         required: false
         type: string
+      enable_mosipid2:
+        description: "Enable MOSIP-ID2 testrig (only needed if mosipid2 eSignet instance is enabled)"
+        required: false
+        default: false
+        type: boolean
       mosipid2_domain_name:
-        description: "MOSIP-ID2 domain name (e.g. mosipenv2.xyz.net) — required for esignet profile"
+        description: "MOSIP-ID2 domain name (e.g. mosipenv2.xyz.net) — required only when enable_mosipid2 is set"
         required: false
         type: string
       db_port:
@@ -81,12 +86,6 @@ jobs:
           [ -z "$SLACK_CH" ]        && errors+=("slack_channel_name is empty — set vars.SLACK_CHANNEL_NAME under Environment '${{ github.ref_name }}'")
           [ -z "$DB_PORT" ]         && errors+=("db_port is empty — set vars.DB_PORT under Environment '${{ github.ref_name }}'")
           [ -z "$ESIGNET_DB_PORT" ] && errors+=("esignet_db_port is empty — set vars.ESIGNET_DB_PORT under Environment '${{ github.ref_name }}'")
-          if [ -z "$PROFILE" ] || [[ "$PROFILE" == esignet-standalone* ]]; then
-            MOSIPID1_DOMAIN="${{ github.event.inputs.mosipid1_domain_name || vars.MOSIPID1_DOMAIN_NAME }}"
-            MOSIPID2_DOMAIN="${{ github.event.inputs.mosipid2_domain_name || vars.MOSIPID2_DOMAIN_NAME }}"
-            [ -z "$MOSIPID1_DOMAIN" ]    && errors+=("mosipid1_domain_name is empty — set vars.MOSIPID1_DOMAIN_NAME under Environment '${{ github.ref_name }}'")
-            [ -z "$MOSIPID2_DOMAIN" ] && errors+=("mosipid2_domain_name is empty — set vars.MOSIPID2_DOMAIN_NAME under Environment '${{ github.ref_name }}'")
-          fi
           if [ ${#errors[@]} -gt 0 ]; then
             echo "❌ Required variables missing:"
             printf '  - %s\n' "${errors[@]}"
@@ -98,9 +97,19 @@ jobs:
           echo "✓ slack_channel_name = $SLACK_CH"
           echo "✓ db_port            = $DB_PORT"
           echo "✓ esignet_db_port    = $ESIGNET_DB_PORT"
+          # mosipid1_domain_name and mosipid2_domain_name are esignet standalone only.
+          # Push events always target the esignet profile (path filter); dispatch uses explicit profile input.
           if [ -z "$PROFILE" ] || [[ "$PROFILE" == esignet-standalone* ]]; then
-            echo "✓ mosipid1_domain_name    = $MOSIPID1_DOMAIN (esignet profile)"
-            echo "✓ mosipid2_domain_name = $MOSIPID2_DOMAIN (esignet profile)"
+            MOSIPID1_DOMAIN="${{ github.event.inputs.mosipid1_domain_name || vars.MOSIPID1_DOMAIN_NAME }}"
+            MOSIPID2_DOMAIN="${{ github.event.inputs.mosipid2_domain_name || vars.MOSIPID2_DOMAIN_NAME }}"
+            echo "✓ mosipid1_domain_name = $MOSIPID1_DOMAIN (esignet standalone)"
+            echo "✓ mosipid2_domain_name = $MOSIPID2_DOMAIN (esignet standalone)"
+          else
+            MOSIPID1_PROVIDED="${{ github.event.inputs.mosipid1_domain_name }}"
+            MOSIPID2_PROVIDED="${{ github.event.inputs.mosipid2_domain_name }}"
+            if [ -n "$MOSIPID1_PROVIDED" ] || [ -n "$MOSIPID2_PROVIDED" ]; then
+              echo "⚠ mosipid1_domain_name / mosipid2_domain_name are only used for esignet standalone profile — ignoring for profile=$PROFILE"
+            fi
           fi
 
   deploy:
@@ -115,6 +124,7 @@ jobs:
       domain_name:        ${{ github.event.inputs.domain_name        || vars.DOMAIN_NAME }}
       mosipid1_domain_name:    ${{ github.event.inputs.mosipid1_domain_name    || vars.MOSIPID1_DOMAIN_NAME }}
       mosipid2_domain_name: ${{ github.event.inputs.mosipid2_domain_name || vars.MOSIPID2_DOMAIN_NAME }}
+      MOSIPID2_ENABLED:   ${{ github.event.inputs.enable_mosipid2 == 'true' && 'true' || 'false' }}
       db_port:            ${{ github.event.inputs.db_port            || vars.DB_PORT }}
       esignet_db_port:    ${{ github.event.inputs.esignet_db_port    || vars.ESIGNET_DB_PORT }}
       env_name:           ${{ github.event.inputs.env_name           || vars.ENV_NAME }}

--- a/Helmsman/dsf/esignet-standalone-2.0.0/testrigs-dsf.yaml
+++ b/Helmsman/dsf/esignet-standalone-2.0.0/testrigs-dsf.yaml
@@ -125,7 +125,7 @@ apps:
   # ---------------------------------------------------------------------------
   esignet-go-mosipid2-apitestrig:
     namespace: esignet-go-mosipid2
-    enabled: true
+    enabled: ${MOSIPID2_ENABLED}
     version: 0.0.1-develop
     chart: mosip/apitestrig
     valuesFile: "$WORKDIR/utils/esignet-apitestrig-values.yaml"

--- a/Helmsman/dsf/esignet-standalone/testrigs-dsf.yaml
+++ b/Helmsman/dsf/esignet-standalone/testrigs-dsf.yaml
@@ -125,7 +125,7 @@ apps:
   # ---------------------------------------------------------------------------
   esignet-mosipid2-apitestrig:
     namespace: esignet-mosipid2
-    enabled: true
+    enabled: ${MOSIPID2_ENABLED}
     version: 0.0.1-develop
     chart: mosip/apitestrig
     valuesFile: "$WORKDIR/utils/esignet-apitestrig-values.yaml"


### PR DESCRIPTION
## Summary
- Adds an `enable_mosipid2` toggle to `helmsman_testrigs.yml`, matching `helmsman_esignet.yml`.
- Removes the unconditional hard-requirement on `mosipid1_domain_name`/`mosipid2_domain_name` in `validate-inputs` — it was failing validation for esignet-standalone* profiles whenever mosipid2 wasn't enabled. Now echo-only, consistent with `helmsman_esignet.yml`.
- Gates the mosipid2 apitestrig's `enabled` field in both `Helmsman/dsf/esignet-standalone/testrigs-dsf.yaml` and `Helmsman/dsf/esignet-standalone-2.0.0/testrigs-dsf.yaml` behind `${MOSIPID2_ENABLED}` instead of hardcoding `true`.

Refs #302

## Test plan
- [x] YAML parse check on both edited testrigs-dsf.yaml files and the workflow file
- [x] actionlint/shellcheck on the workflow file (only pre-existing unrelated style nits)
- [ ] Trigger `helmsman_testrigs.yml` for `esignet-standalone-2.0.0` with `enable_mosipid2` unset to confirm validation no longer fails on mosipid2_domain_name

🤖 Generated with [Claude Code](https://claude.com/claude-code)